### PR TITLE
revise default max change of lat and lon in relocation

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -298,7 +298,7 @@ inline       CUSTOMREAL DIST_SRC_DDT        = 2.5*DEG2RAD; // distance threshold
 inline const std::string OUTPUT_DIR_2D      = "/2D_TRAVEL_TIME_FIELD/"; // output directory for 2d solver
 
 // earthquake relocation
-inline CUSTOMREAL       step_length_src_reloc       = 2.0;  // step length for source relocation
+inline CUSTOMREAL       step_length_src_reloc       = 0.01;  // step length for source relocation
 inline CUSTOMREAL       step_length_decay_src_reloc = 0.9;
 inline int              N_ITER_MAX_SRC_RELOC        = 501;  // max iteration for source location
 inline CUSTOMREAL       TOL_SRC_RELOC               = 1e-3; // threshold of the norm of gradient for stopping single earthquake location


### PR DESCRIPTION
revise default max change of lat (km) and lon (km) in relocation, making them consistent with max change of depth (km)