### PR TITLE
ver1.1.2: fix near zero value in domain decomposed kernel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 # set the project name
 set(CMAKE_PROJECT_NAME "TOMOATT")
-project(${CMAKE_PROJECT_NAME} VERSION 1.1.1 LANGUAGES C CXX )
+project(${CMAKE_PROJECT_NAME} VERSION 1.1.2 LANGUAGES C CXX )
 
 # set install directory
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.10)
 
 # set the project name
 set(CMAKE_PROJECT_NAME "TOMOATT")
-project(${CMAKE_PROJECT_NAME} VERSION 1.1.2 LANGUAGES C CXX )
+project(${CMAKE_PROJECT_NAME} VERSION 1.1.1 LANGUAGES C CXX )
 
 # set install directory
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/include/model_update.h
+++ b/include/model_update.h
@@ -44,10 +44,6 @@ void smooth_kernels(Grid& grid, InputParams& IP) {
                     }
                 }
             }
-            CUSTOMREAL tmp;
-            allreduce_cr_single_max(max_kernel, tmp);
-            max_kernel = tmp;
-            
             if (max_kernel <= eps) {    
                 std::cout << "Error: max_kernel is near zero (less than 10^-12), check data residual and whether no data is used" << std::endl;
                 exit(1);

--- a/include/model_update.h
+++ b/include/model_update.h
@@ -44,6 +44,10 @@ void smooth_kernels(Grid& grid, InputParams& IP) {
                     }
                 }
             }
+            CUSTOMREAL tmp = 0;
+            allreduce_cr_single_max(max_kernel, tmp);
+            max_kernel = tmp;
+
             if (max_kernel <= eps) {    
                 std::cout << "Error: max_kernel is near zero (less than 10^-12), check data residual and whether no data is used" << std::endl;
                 exit(1);

--- a/include/model_update.h
+++ b/include/model_update.h
@@ -44,6 +44,10 @@ void smooth_kernels(Grid& grid, InputParams& IP) {
                     }
                 }
             }
+            CUSTOMREAL tmp;
+            allreduce_cr_single_max(max_kernel, tmp);
+            max_kernel = tmp;
+            
             if (max_kernel <= eps) {    
                 std::cout << "Error: max_kernel is near zero (less than 10^-12), check data residual and whether no data is used" << std::endl;
                 exit(1);


### PR DESCRIPTION
This is a serious bug. At least two users have reported encountering it

In the previous version, when using multiple subdomains, the maximum value of kernel is computed within each subdomain. However, the correct value should be computed across all subdomains.

As a result, if the kernel in one subdomain is near zero, the code will incorrectly terminate.

This update fix this bug.