### PR TITLE
Optimise calculate_stencil_1st_order_upwind, update deprecated MPI_CXX_BOOL to MPI_C_BOOL

### DIFF
--- a/include/iterator.h
+++ b/include/iterator.h
@@ -132,7 +132,7 @@ protected:
     CUSTOMREAL at1, bt1, at2, bt2, at, bt;
     CUSTOMREAL ar1, br1, ar2, br2, ar, br;
 
-    CUSTOMREAL bc_f2, eqn_a, eqn_b, eqn_c, eqn_Delta;
+    CUSTOMREAL bc_f2, eqn_a, eqn_b, eqn_c, eqn_Delta, eqn_Delta_sqrt, fun_loc_sq, fun_loc_sqrt;
     CUSTOMREAL tmp_tau, tmp_T;
     CUSTOMREAL T_r, T_t, T_p, charact_r, charact_t, charact_p;
     bool is_causality;

--- a/include/iterator.h
+++ b/include/iterator.h
@@ -132,8 +132,8 @@ protected:
     CUSTOMREAL at1, bt1, at2, bt2, at, bt;
     CUSTOMREAL ar1, br1, ar2, br2, ar, br;
 
-    CUSTOMREAL bc_f2, eqn_a, eqn_b, eqn_c, eqn_Delta, eqn_Delta_sqrt, fun_loc_sq, fun_loc_sqrt;
-    CUSTOMREAL tmp_tau, tmp_T;
+    CUSTOMREAL bc_f2, eqn_a, eqn_b, eqn_c, eqn_Delta, eqn_Delta_sqrt, fun_loc_sq, fun_loc_sqrt, one_over_a;
+    CUSTOMREAL tmp_tau, tmp_T, bc_over_b, bc_over_c;
     CUSTOMREAL T_r, T_t, T_p, charact_r, charact_t, charact_p;
     bool is_causality;
     int count_cand;

--- a/include/mpi_funcs.h
+++ b/include/mpi_funcs.h
@@ -619,29 +619,29 @@ inline void allreduce_cr_single(CUSTOMREAL& loc_buf, CUSTOMREAL& all_buf){
 
 inline void allreduce_bool_inplace_inter_sim(bool* loc_buf, int count){
     // return true if any of the processes return true
-    MPI_Allreduce(MPI_IN_PLACE, loc_buf, count, MPI_CXX_BOOL, MPI_LOR, inter_sim_comm);
+    MPI_Allreduce(MPI_IN_PLACE, loc_buf, count, MPI_C_BOOL, MPI_LOR, inter_sim_comm);
 }
 
 
 inline void allreduce_bool_inplace(bool* loc_buf, int count){
     // return true if any of the processes return true
-    MPI_Allreduce(MPI_IN_PLACE, loc_buf, count, MPI_CXX_BOOL, MPI_LOR, inter_sub_comm);
+    MPI_Allreduce(MPI_IN_PLACE, loc_buf, count, MPI_C_BOOL, MPI_LOR, inter_sub_comm);
 }
 
 
 inline void allreduce_bool_inplace_sub(bool* loc_buf, int count){
     // return true if any of the processes return true
-    MPI_Allreduce(MPI_IN_PLACE, loc_buf, count, MPI_CXX_BOOL, MPI_LOR, sub_comm);
+    MPI_Allreduce(MPI_IN_PLACE, loc_buf, count, MPI_C_BOOL, MPI_LOR, sub_comm);
 }
 
 
 inline void allreduce_bool_single_inplace(bool& loc_buf){
-    MPI_Allreduce(MPI_IN_PLACE, &loc_buf, 1, MPI_CXX_BOOL, MPI_LAND, inter_sub_comm);
+    MPI_Allreduce(MPI_IN_PLACE, &loc_buf, 1, MPI_C_BOOL, MPI_LAND, inter_sub_comm);
 }
 
 // true if all processes return true else false
 inline void allreduce_bool_single_inplace_sim(bool& loc_buf){
-    MPI_Allreduce(MPI_IN_PLACE, &loc_buf, 1, MPI_CXX_BOOL, MPI_LAND, inter_sim_comm);
+    MPI_Allreduce(MPI_IN_PLACE, &loc_buf, 1, MPI_C_BOOL, MPI_LAND, inter_sim_comm);
 }
 
 inline void allreduce_i_inplace(int* loc_buf, int count){
@@ -692,22 +692,22 @@ inline void allgather_cr_single(CUSTOMREAL* loc_buf, CUSTOMREAL* all_buf){
 
 inline void allgather_bool_single(bool* loc_buf, bool* all_buf){
     int count = 1;
-    MPI_Allgather(loc_buf, count, MPI_CXX_BOOL, all_buf, count, MPI_CXX_BOOL, inter_sub_comm);
+    MPI_Allgather(loc_buf, count, MPI_C_BOOL, all_buf, count, MPI_C_BOOL, inter_sub_comm);
 }
 
 inline void broadcast_bool_single(bool& value, int root){
     int count = 1;
-    MPI_Bcast(&value, count, MPI_CXX_BOOL, root, inter_sub_comm);
+    MPI_Bcast(&value, count, MPI_C_BOOL, root, inter_sub_comm);
 }
 
 inline void broadcast_bool_single_sub(bool& value, int root){
     int count = 1;
-    MPI_Bcast(&value, count, MPI_CXX_BOOL, root, sub_comm);
+    MPI_Bcast(&value, count, MPI_C_BOOL, root, sub_comm);
 }
 
 inline void broadcast_bool_single_inter_sim(bool& value, int root){
     int count = 1;
-    MPI_Bcast(&value, count, MPI_CXX_BOOL, root, inter_sim_comm);
+    MPI_Bcast(&value, count, MPI_C_BOOL, root, inter_sim_comm);
 }
 
 inline void broadcast_bool_inter_and_intra_sim(bool& value, int root){

--- a/src/iterator.cpp
+++ b/src/iterator.cpp
@@ -1771,7 +1771,7 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
         // simply, we have two solutions
         for (int i_solution = 0; i_solution < 2; i_solution++){
             fun_loc_sqrt = std::sqrt(fun_loc_sq*grid.fac_c_loc[ii]/bc_f2); 
-            one_over_a = at;
+            one_over_a = 1/at;
             // solutions
             switch (i_solution){
                 case 0:
@@ -1849,7 +1849,7 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
         // simply, we have two solutions
         for (int i_solution = 0; i_solution < 2; i_solution++){
             fun_loc_sqrt = std::sqrt(fun_loc_sq*grid.fac_b_loc[ii]/bc_f2); 
-            one_over_a = ap;
+            one_over_a = 1/ap;
             // solutions
             switch (i_solution){
                 case 0:

--- a/src/iterator.cpp
+++ b/src/iterator.cpp
@@ -1048,6 +1048,8 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
         br2 =  grid.T0v_loc[ii]/dr*grid.tau_loc[ii_pr];
     }
     bc_f2 = grid.fac_b_loc[ii]*grid.fac_c_loc[ii] - grid.fac_f_loc[ii]*grid.fac_f_loc[ii];
+    bc_over_b = bc_f2/grid.fac_b_loc[ii];
+    bc_over_c = bc_f2/grid.fac_c_loc[ii];
     fun_loc_sq = grid.fun_loc[ii]*grid.fun_loc[ii];
 
     // start to find candidate solutions
@@ -1128,14 +1130,15 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
 
         if (eqn_Delta >= 0){    // one or two real solutions
             eqn_Delta_sqrt = std::sqrt(eqn_Delta);
+            one_over_a = 1 / (_2_CR*eqn_a);
             for (int i_solution = 0; i_solution < 2; i_solution++){
                 // solutions
                 switch (i_solution){
                     case 0:
-                        tmp_tau = (-eqn_b + eqn_Delta_sqrt)/(_2_CR*eqn_a);
+                        tmp_tau = (-eqn_b + eqn_Delta_sqrt)*one_over_a;
                         break;
                     case 1:
-                        tmp_tau = (-eqn_b - eqn_Delta_sqrt)/(_2_CR*eqn_a);
+                        tmp_tau = (-eqn_b - eqn_Delta_sqrt)*one_over_a;
                         break;
                 }
 
@@ -1302,22 +1305,23 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
         }
 
         // plug T_t, T_r into eikonal equation, solve the quadratic equation:  a*(ar*tau+br)^2 + (bc-f^2)/c*(at*tau+bt)^2 = s^2
-        eqn_a = grid.fac_a_loc[ii] * ar*ar + bc_f2/grid.fac_c_loc[ii] * at*at;
-        eqn_b = _2_CR*grid.fac_a_loc[ii] * ar * br + _2_CR*bc_f2/grid.fac_c_loc[ii] * at * bt;
-        eqn_c = grid.fac_a_loc[ii] * br*br + bc_f2/grid.fac_c_loc[ii] * bt*bt
+        eqn_a = grid.fac_a_loc[ii] * ar*ar + bc_over_c * at*at;
+        eqn_b = _2_CR*grid.fac_a_loc[ii] * ar * br + _2_CR*bc_over_c * at * bt;
+        eqn_c = grid.fac_a_loc[ii] * br*br + bc_over_c * bt*bt
               - fun_loc_sq;
         eqn_Delta = eqn_b*eqn_b - _4_CR * eqn_a * eqn_c;
 
         if (eqn_Delta >= 0){    // one or two real solutions
             eqn_Delta_sqrt = std::sqrt(eqn_Delta);
+            one_over_a = 1 / (_2_CR*eqn_a);
             for (int i_solution = 0; i_solution < 2; i_solution++){
                 // solutions
                 switch (i_solution){
                     case 0:
-                        tmp_tau = (-eqn_b + eqn_Delta_sqrt)/(_2_CR*eqn_a);
+                        tmp_tau = (-eqn_b + eqn_Delta_sqrt)*one_over_a;
                         break;
                     case 1:
-                        tmp_tau = (-eqn_b - eqn_Delta_sqrt)/(_2_CR*eqn_a);
+                        tmp_tau = (-eqn_b - eqn_Delta_sqrt)*one_over_a;
                         break;
                 }
 
@@ -1326,7 +1330,7 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
                 T_t = at*tmp_tau + bt;
 
                 charact_r = grid.fac_a_loc[ii]*T_r;
-                charact_t = bc_f2/grid.fac_c_loc[ii]*T_t;
+                charact_t = bc_over_c*T_t;
 
                 is_causality = false;
                 switch (i_case){
@@ -1428,22 +1432,23 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
         }
 
         // plug T_p, T_r into eikonal equation, solve the quadratic equation:  a*(ar*tau+br)^2 + (bc-f^2)/b*(ap*tau+bp)^2 = s^2
-        eqn_a = grid.fac_a_loc[ii] * ar*ar + bc_f2/grid.fac_b_loc[ii] * ap*ap;
-        eqn_b = _2_CR*grid.fac_a_loc[ii] * ar * br + _2_CR*bc_f2/grid.fac_b_loc[ii] * ap * bp;
-        eqn_c = grid.fac_a_loc[ii] * br*br + bc_f2/grid.fac_b_loc[ii] * bp*bp
+        eqn_a = grid.fac_a_loc[ii] * ar*ar + bc_over_b * ap*ap;
+        eqn_b = _2_CR*grid.fac_a_loc[ii] * ar * br + _2_CR*bc_over_b * ap * bp;
+        eqn_c = grid.fac_a_loc[ii] * br*br + bc_over_b * bp*bp
               - fun_loc_sq;
         eqn_Delta = eqn_b*eqn_b - _4_CR * eqn_a * eqn_c;
 
         if (eqn_Delta >= 0){    // one or two real solutions
             eqn_Delta_sqrt = std::sqrt(eqn_Delta);
+            one_over_a = 1 / (_2_CR*eqn_a);
             for (int i_solution = 0; i_solution < 2; i_solution++){
                 // solutions
                 switch (i_solution){
                     case 0:
-                        tmp_tau = (-eqn_b + eqn_Delta_sqrt)/(_2_CR*eqn_a);
+                        tmp_tau = (-eqn_b + eqn_Delta_sqrt)*one_over_a;
                         break;
                     case 1:
-                        tmp_tau = (-eqn_b - eqn_Delta_sqrt)/(_2_CR*eqn_a);
+                        tmp_tau = (-eqn_b - eqn_Delta_sqrt)*one_over_a;
                         break;
                 }
 
@@ -1452,7 +1457,7 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
                 T_p = ap*tmp_tau + bp;
 
                 charact_r = grid.fac_a_loc[ii]*T_r;
-                charact_p = bc_f2/grid.fac_b_loc[ii]*T_p;
+                charact_p = bc_over_b*T_p;
 
                 is_causality = false;
                 switch (i_case){
@@ -1564,14 +1569,15 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
 
         if (eqn_Delta >= 0){    // one or two real solutions
             eqn_Delta_sqrt = std::sqrt(eqn_Delta);
+            one_over_a = 1 / (_2_CR*eqn_a);
             for (int i_solution = 0; i_solution < 2; i_solution++){
                 // solutions
                 switch (i_solution){
                     case 0:
-                        tmp_tau = (-eqn_b + eqn_Delta_sqrt)/(_2_CR*eqn_a);
+                        tmp_tau = (-eqn_b + eqn_Delta_sqrt)*one_over_a;
                         break;
                     case 1:
-                        tmp_tau = (-eqn_b - eqn_Delta_sqrt)/(_2_CR*eqn_a);
+                        tmp_tau = (-eqn_b - eqn_Delta_sqrt)*one_over_a;
                         break;
                 }
 
@@ -1688,13 +1694,14 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
         // simply, we have two solutions
         for (int i_solution = 0; i_solution < 2; i_solution++){
             fun_loc_sqrt = std::sqrt(fun_loc_sq/grid.fac_a_loc[ii]);
+            one_over_a = 1/ar;
             // solutions
             switch (i_solution){
                 case 0:
-                    tmp_tau = ( fun_loc_sqrt - br)/ar;
+                    tmp_tau = ( fun_loc_sqrt - br)*one_over_a;
                     break;
                 case 1:
-                    tmp_tau = (-fun_loc_sqrt - br)/ar;
+                    tmp_tau = (-fun_loc_sqrt - br)*one_over_a;
                     break;
             }
 
@@ -1704,13 +1711,13 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
             switch (i_case){
                 case 0:  //characteristic travels from -r (we can simply compare the traveltime, which is the same as check the direction of characteristic)
                     if (tmp_tau * grid.T0v_loc[ii] > grid.tau_loc[ii_mr] * grid.T0v_loc[ii_mr]
-                        && tmp_tau > grid.tau_loc[ii_mr]/_2_CR && tmp_tau > 0){   // this additional condition ensures the causality near the source
+                        && _2_CR*tmp_tau > grid.tau_loc[ii_mr] && tmp_tau > 0){   // this additional condition ensures the causality near the source
                         is_causality = true;
                     }
                     break;
                 case 1:  //characteristic travels from +r
                     if (tmp_tau * grid.T0v_loc[ii] > grid.tau_loc[ii_pr] * grid.T0v_loc[ii_pr]
-                        && tmp_tau > grid.tau_loc[ii_pr]/_2_CR && tmp_tau > 0){
+                        && _2_CR*tmp_tau > grid.tau_loc[ii_pr] && tmp_tau > 0){
                         is_causality = true;
                     }
                     break;
@@ -1764,13 +1771,14 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
         // simply, we have two solutions
         for (int i_solution = 0; i_solution < 2; i_solution++){
             fun_loc_sqrt = std::sqrt(fun_loc_sq*grid.fac_c_loc[ii]/bc_f2); 
+            one_over_a = at;
             // solutions
             switch (i_solution){
                 case 0:
-                    tmp_tau = ( fun_loc_sqrt - bt)/at;
+                    tmp_tau = ( fun_loc_sqrt - bt)*one_over_a;
                     break;
                 case 1:
-                    tmp_tau = (-fun_loc_sqrt - bt)/at;
+                    tmp_tau = (-fun_loc_sqrt - bt)*one_over_a;
                     break;
             }
 
@@ -1780,13 +1788,13 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
             switch (i_case){
                 case 2:  //characteristic travels from -t (we can simply compare the traveltime, which is the same as check the direction of characteristic)
                     if (tmp_tau * grid.T0v_loc[ii] > grid.tau_loc[ii_mt] * grid.T0v_loc[ii_mt]
-                        && tmp_tau > grid.tau_loc[ii_mt]/_2_CR && tmp_tau > 0){   // this additional condition ensures the causality near the source
+                        && _2_CR*tmp_tau > grid.tau_loc[ii_mt] && tmp_tau > 0){   // this additional condition ensures the causality near the source
                         is_causality = true;
                     }
                     break;
                 case 3:  //characteristic travels from +t
                     if (tmp_tau * grid.T0v_loc[ii] > grid.tau_loc[ii_pt] * grid.T0v_loc[ii_pt]
-                        && tmp_tau > grid.tau_loc[ii_pt]/_2_CR && tmp_tau > 0){
+                        && _2_CR*tmp_tau > grid.tau_loc[ii_pt] && tmp_tau > 0){
                         is_causality = true;
                     }
                     break;
@@ -1841,13 +1849,14 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
         // simply, we have two solutions
         for (int i_solution = 0; i_solution < 2; i_solution++){
             fun_loc_sqrt = std::sqrt(fun_loc_sq*grid.fac_b_loc[ii]/bc_f2); 
+            one_over_a = ap;
             // solutions
             switch (i_solution){
                 case 0:
-                    tmp_tau = ( fun_loc_sqrt - bp)/ap;
+                    tmp_tau = ( fun_loc_sqrt - bp)*one_over_a;
                     break;
                 case 1:
-                    tmp_tau = (-fun_loc_sqrt - bp)/ap;
+                    tmp_tau = (-fun_loc_sqrt - bp)*one_over_a;
                     break;
             }
 
@@ -1857,13 +1866,13 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
             switch (i_case){
                 case 4:  //characteristic travels from -p (we can simply compare the traveltime, which is the same as check the direction of characteristic)
                     if (tmp_tau * grid.T0v_loc[ii] > grid.tau_loc[ii_mp] * grid.T0v_loc[ii_mp]
-                        && tmp_tau > grid.tau_loc[ii_mp]/_2_CR && tmp_tau > 0){   // this additional condition ensures the causality near the source
+                        && _2_CR*tmp_tau > grid.tau_loc[ii_mp] && tmp_tau > 0){   // this additional condition ensures the causality near the source
                         is_causality = true;
                     }
                     break;
                 case 5:  //characteristic travels from +p
                     if (tmp_tau * grid.T0v_loc[ii] > grid.tau_loc[ii_pp] * grid.T0v_loc[ii_pp]
-                        && tmp_tau > grid.tau_loc[ii_pp]/_2_CR && tmp_tau > 0){
+                        && _2_CR*tmp_tau > grid.tau_loc[ii_pp] && tmp_tau > 0){
                         is_causality = true;
                     }
                     break;

--- a/src/iterator.cpp
+++ b/src/iterator.cpp
@@ -1047,7 +1047,8 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
         ar2 =  grid.T0r_loc[ii] - grid.T0v_loc[ii]/dr;
         br2 =  grid.T0v_loc[ii]/dr*grid.tau_loc[ii_pr];
     }
-    bc_f2 = grid.fac_b_loc[ii]*grid.fac_c_loc[ii] - std::pow(grid.fac_f_loc[ii],_2_CR);
+    bc_f2 = grid.fac_b_loc[ii]*grid.fac_c_loc[ii] - grid.fac_f_loc[ii]*grid.fac_f_loc[ii];
+    fun_loc_sq = grid.fun_loc[ii]*grid.fun_loc[ii];
 
     // start to find candidate solutions
 
@@ -1116,24 +1117,25 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
 
         // plug T_p, T_t, T_r into eikonal equation, solving the quadratic equation with respect to tau(iip,jjt,kkr)
         // that is a*(ar*tau+br)^2 + b*(at*tau+bt)^2 + c*(ap*tau+bp)^2 - 2*f*(at*tau+bt)*(ap*tau+bp) = s^2
-        eqn_a = grid.fac_a_loc[ii] * std::pow(ar, _2_CR) + grid.fac_b_loc[ii] * std::pow(at, _2_CR)
-              + grid.fac_c_loc[ii] * std::pow(ap, _2_CR) - _2_CR*grid.fac_f_loc[ii] * at * ap;
+        eqn_a = grid.fac_a_loc[ii] * ar*ar + grid.fac_b_loc[ii] * at*at
+              + grid.fac_c_loc[ii] * ap*ap - _2_CR*grid.fac_f_loc[ii] * at * ap;
         eqn_b = _2_CR*grid.fac_a_loc[ii] * ar * br + _2_CR*grid.fac_b_loc[ii] * at * bt
               + _2_CR*grid.fac_c_loc[ii] * ap * bp - _2_CR*grid.fac_f_loc[ii] * (at*bp + bt*ap);
-        eqn_c = grid.fac_a_loc[ii] * std::pow(br, _2_CR) + grid.fac_b_loc[ii] * std::pow(bt, _2_CR)
-              + grid.fac_c_loc[ii] * std::pow(bp, _2_CR) - _2_CR*grid.fac_f_loc[ii] * bt * bp
-              - std::pow(grid.fun_loc[ii], _2_CR);
-        eqn_Delta = std::pow(eqn_b, _2_CR) - _4_CR * eqn_a * eqn_c;
+        eqn_c = grid.fac_a_loc[ii] * br*br + grid.fac_b_loc[ii] * bt*bt
+              + grid.fac_c_loc[ii] * bp*bp - _2_CR*grid.fac_f_loc[ii] * bt * bp
+              - fun_loc_sq;
+        eqn_Delta = eqn_b*eqn_b - _4_CR * eqn_a * eqn_c;
 
         if (eqn_Delta >= 0){    // one or two real solutions
+            eqn_Delta_sqrt = std::sqrt(eqn_Delta);
             for (int i_solution = 0; i_solution < 2; i_solution++){
                 // solutions
                 switch (i_solution){
                     case 0:
-                        tmp_tau = (-eqn_b + std::sqrt(eqn_Delta))/(_2_CR*eqn_a);
+                        tmp_tau = (-eqn_b + eqn_Delta_sqrt)/(_2_CR*eqn_a);
                         break;
                     case 1:
-                        tmp_tau = (-eqn_b - std::sqrt(eqn_Delta))/(_2_CR*eqn_a);
+                        tmp_tau = (-eqn_b - eqn_Delta_sqrt)/(_2_CR*eqn_a);
                         break;
                 }
 
@@ -1300,21 +1302,22 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
         }
 
         // plug T_t, T_r into eikonal equation, solve the quadratic equation:  a*(ar*tau+br)^2 + (bc-f^2)/c*(at*tau+bt)^2 = s^2
-        eqn_a = grid.fac_a_loc[ii] * std::pow(ar, _2_CR) + bc_f2/grid.fac_c_loc[ii] * std::pow(at, _2_CR);
+        eqn_a = grid.fac_a_loc[ii] * ar*ar + bc_f2/grid.fac_c_loc[ii] * at*at;
         eqn_b = _2_CR*grid.fac_a_loc[ii] * ar * br + _2_CR*bc_f2/grid.fac_c_loc[ii] * at * bt;
-        eqn_c = grid.fac_a_loc[ii] * std::pow(br, _2_CR) + bc_f2/grid.fac_c_loc[ii] * std::pow(bt, _2_CR)
-              - std::pow(grid.fun_loc[ii], _2_CR);
-        eqn_Delta = std::pow(eqn_b, _2_CR) - _4_CR * eqn_a * eqn_c;
+        eqn_c = grid.fac_a_loc[ii] * br*br + bc_f2/grid.fac_c_loc[ii] * bt*bt
+              - fun_loc_sq;
+        eqn_Delta = eqn_b*eqn_b - _4_CR * eqn_a * eqn_c;
 
         if (eqn_Delta >= 0){    // one or two real solutions
+            eqn_Delta_sqrt = std::sqrt(eqn_Delta);
             for (int i_solution = 0; i_solution < 2; i_solution++){
                 // solutions
                 switch (i_solution){
                     case 0:
-                        tmp_tau = (-eqn_b + std::sqrt(eqn_Delta))/(_2_CR*eqn_a);
+                        tmp_tau = (-eqn_b + eqn_Delta_sqrt)/(_2_CR*eqn_a);
                         break;
                     case 1:
-                        tmp_tau = (-eqn_b - std::sqrt(eqn_Delta))/(_2_CR*eqn_a);
+                        tmp_tau = (-eqn_b - eqn_Delta_sqrt)/(_2_CR*eqn_a);
                         break;
                 }
 
@@ -1425,21 +1428,22 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
         }
 
         // plug T_p, T_r into eikonal equation, solve the quadratic equation:  a*(ar*tau+br)^2 + (bc-f^2)/b*(ap*tau+bp)^2 = s^2
-        eqn_a = grid.fac_a_loc[ii] * std::pow(ar, _2_CR) + bc_f2/grid.fac_b_loc[ii] * std::pow(ap, _2_CR);
+        eqn_a = grid.fac_a_loc[ii] * ar*ar + bc_f2/grid.fac_b_loc[ii] * ap*ap;
         eqn_b = _2_CR*grid.fac_a_loc[ii] * ar * br + _2_CR*bc_f2/grid.fac_b_loc[ii] * ap * bp;
-        eqn_c = grid.fac_a_loc[ii] * std::pow(br, _2_CR) + bc_f2/grid.fac_b_loc[ii] * std::pow(bp, _2_CR)
-              - std::pow(grid.fun_loc[ii], _2_CR);
-        eqn_Delta = std::pow(eqn_b, _2_CR) - _4_CR * eqn_a * eqn_c;
+        eqn_c = grid.fac_a_loc[ii] * br*br + bc_f2/grid.fac_b_loc[ii] * bp*bp
+              - fun_loc_sq;
+        eqn_Delta = eqn_b*eqn_b - _4_CR * eqn_a * eqn_c;
 
         if (eqn_Delta >= 0){    // one or two real solutions
+            eqn_Delta_sqrt = std::sqrt(eqn_Delta);
             for (int i_solution = 0; i_solution < 2; i_solution++){
                 // solutions
                 switch (i_solution){
                     case 0:
-                        tmp_tau = (-eqn_b + std::sqrt(eqn_Delta))/(_2_CR*eqn_a);
+                        tmp_tau = (-eqn_b + eqn_Delta_sqrt)/(_2_CR*eqn_a);
                         break;
                     case 1:
-                        tmp_tau = (-eqn_b - std::sqrt(eqn_Delta))/(_2_CR*eqn_a);
+                        tmp_tau = (-eqn_b - eqn_Delta_sqrt)/(_2_CR*eqn_a);
                         break;
                 }
 
@@ -1549,24 +1553,25 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
         }
 
         // plug T_p, T_t into eikonal equation, solve the quadratic equation:  b*(at*tau+bt)^2 + c*(ap*tau+bp)^2 - 2f*(at*tau+bt)*(ap*tau+bp) = s^2
-        eqn_a = grid.fac_b_loc[ii] * std::pow(at, _2_CR)
-              + grid.fac_c_loc[ii] * std::pow(ap, _2_CR) - _2_CR*grid.fac_f_loc[ii] * at * ap;
+        eqn_a = grid.fac_b_loc[ii] * at*at 
+              + grid.fac_c_loc[ii] * ap*ap - _2_CR*grid.fac_f_loc[ii] * at * ap;
         eqn_b = _2_CR*grid.fac_b_loc[ii] * at * bt
               + _2_CR*grid.fac_c_loc[ii] * ap * bp - _2_CR*grid.fac_f_loc[ii] * (at*bp + bt*ap);
-        eqn_c = grid.fac_b_loc[ii] * std::pow(bt, _2_CR)
-              + grid.fac_c_loc[ii] * std::pow(bp, _2_CR) - _2_CR*grid.fac_f_loc[ii] * bt * bp
-              - std::pow(grid.fun_loc[ii], _2_CR);
-        eqn_Delta = std::pow(eqn_b, _2_CR) - _4_CR * eqn_a * eqn_c;
+        eqn_c = grid.fac_b_loc[ii] * bt*bt
+              + grid.fac_c_loc[ii] * bp*bp - _2_CR*grid.fac_f_loc[ii] * bt * bp
+              - fun_loc_sq;
+        eqn_Delta = eqn_b*eqn_b - _4_CR * eqn_a * eqn_c;
 
         if (eqn_Delta >= 0){    // one or two real solutions
+            eqn_Delta_sqrt = std::sqrt(eqn_Delta);
             for (int i_solution = 0; i_solution < 2; i_solution++){
                 // solutions
                 switch (i_solution){
                     case 0:
-                        tmp_tau = (-eqn_b + std::sqrt(eqn_Delta))/(_2_CR*eqn_a);
+                        tmp_tau = (-eqn_b + eqn_Delta_sqrt)/(_2_CR*eqn_a);
                         break;
                     case 1:
-                        tmp_tau = (-eqn_b - std::sqrt(eqn_Delta))/(_2_CR*eqn_a);
+                        tmp_tau = (-eqn_b - eqn_Delta_sqrt)/(_2_CR*eqn_a);
                         break;
                 }
 
@@ -1682,13 +1687,14 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
         // plug T_t, T_r into eikonal equation, solve the quadratic equation:  a*(ar*tau+br)^2 = s^2
         // simply, we have two solutions
         for (int i_solution = 0; i_solution < 2; i_solution++){
+            fun_loc_sqrt = std::sqrt(fun_loc_sq/grid.fac_a_loc[ii]);
             // solutions
             switch (i_solution){
                 case 0:
-                    tmp_tau = ( std::sqrt(std::pow(grid.fun_loc[ii], _2_CR)/grid.fac_a_loc[ii]) - br)/ar;
+                    tmp_tau = ( fun_loc_sqrt - br)/ar;
                     break;
                 case 1:
-                    tmp_tau = (-std::sqrt(std::pow(grid.fun_loc[ii], _2_CR)/grid.fac_a_loc[ii]) - br)/ar;
+                    tmp_tau = (-fun_loc_sqrt - br)/ar;
                     break;
             }
 
@@ -1757,13 +1763,14 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
         // plug T_p, T_r into eikonal equation, solve the quadratic equation:  (bc-f^2)/c*(at*tau+bt)^2 = s^2
         // simply, we have two solutions
         for (int i_solution = 0; i_solution < 2; i_solution++){
+            fun_loc_sqrt = std::sqrt(fun_loc_sq*grid.fac_c_loc[ii]/bc_f2); 
             // solutions
             switch (i_solution){
                 case 0:
-                    tmp_tau = ( std::sqrt(std::pow(grid.fun_loc[ii], _2_CR)*grid.fac_c_loc[ii]/bc_f2) - bt)/at;
+                    tmp_tau = ( fun_loc_sqrt - bt)/at;
                     break;
                 case 1:
-                    tmp_tau = (-std::sqrt(std::pow(grid.fun_loc[ii], _2_CR)*grid.fac_c_loc[ii]/bc_f2) - bt)/at;
+                    tmp_tau = (-fun_loc_sqrt - bt)/at;
                     break;
             }
 
@@ -1833,13 +1840,14 @@ void Iterator::calculate_stencil_1st_order_upwind(Grid&grid, int&iip, int&jjt, i
         // plug T_t, T_r into eikonal equation, solve the quadratic equation:  (bc-f^2)/b*(ap*tau+bp)^2 = s^2
         // simply, we have two solutions
         for (int i_solution = 0; i_solution < 2; i_solution++){
+            fun_loc_sqrt = std::sqrt(fun_loc_sq*grid.fac_b_loc[ii]/bc_f2); 
             // solutions
             switch (i_solution){
                 case 0:
-                    tmp_tau = ( std::sqrt(std::pow(grid.fun_loc[ii], _2_CR)*grid.fac_b_loc[ii]/bc_f2) - bp)/ap;
+                    tmp_tau = ( fun_loc_sqrt - bp)/ap;
                     break;
                 case 1:
-                    tmp_tau = (-std::sqrt(std::pow(grid.fun_loc[ii], _2_CR)*grid.fac_b_loc[ii]/bc_f2) - bp)/ap;
+                    tmp_tau = (-fun_loc_sqrt - bp)/ap;
                     break;
             }
 


### PR DESCRIPTION
**1 update deprecated MPI_CXX_BOOL to MPI_C_BOOL**

C++ bindings are deprecated in MPI-3.0 standard. this PR allows for TomoATT to work with Cray MPICH by using C MPI bindings.

**2 Optimise calculate_stencil_1st_order_upwind**


- replace pow functions with multiplications
- reduce number of sqrt calls
- reduce number of divisions by replacing with multiplications of inverse

~15% improvement to runtime per iteration of realcase1_regional_tomography_California on 8 CPU cores on ASPIRE 2A.

