### PR TITLE
Devel reduce ram bfgs

### DIFF
--- a/include/grid.h
+++ b/include/grid.h
@@ -344,7 +344,7 @@ public:
     std::vector<CUSTOMREAL> Kxi_density_processing_loc;
     std::vector<CUSTOMREAL> Keta_density_processing_loc;
     // model update para
-    CUSTOMREAL *Ks_update_loc;              // desceent direction (modified kernel)
+    CUSTOMREAL *Ks_update_loc;              // model update (perturbation)
     CUSTOMREAL *Kxi_update_loc;
     CUSTOMREAL *Keta_update_loc;
     CUSTOMREAL *Ks_density_update_loc;

--- a/include/kernel_postprocessing.h
+++ b/include/kernel_postprocessing.h
@@ -20,8 +20,8 @@ namespace Kernel_postprocessing {
     // normalize kernels to -1 ~ 1
     void normalize_kernels(Grid& grid);
 
-    // assign processing kernels to modified kernels for model update
-    void assign_to_modified_kernels(Grid& grid);
+    // assign processing kernels to model update (perturbation)
+    void assign_to_model_update(Grid& grid);
 
     // ---------------------------------------------------
     // ------------------ sub functions ------------------

--- a/include/optimizer.h
+++ b/include/optimizer.h
@@ -46,8 +46,8 @@ protected:
     // smooth kernels (multigrid) + kernel normalization (kernel density normalization)
     virtual void processing_kernels(InputParams& IP, Grid& grid, IO_utils& io, int& i_inv);
 
-    // write out modified kernels (descent direction)
-    void write_modified_kernels(InputParams& IP, Grid& grid, IO_utils& io, int& i_inv);
+    // write out model_update (Ks_update_loc, Kxi_update_loc, Keta_update_loc)
+    void write_model_update(InputParams& IP, Grid& grid, IO_utils& io, int& i_inv);
 
     // determine step length (original method step-size controlled)
     void determine_step_length_controlled(InputParams& IP, Grid& grid, int i_inv, CUSTOMREAL& v_obj_inout, CUSTOMREAL& old_v_obj);
@@ -65,8 +65,8 @@ protected:
     // ------------------ sub functions ------------------
     // ---------------------------------------------------
 
-    // initialize and backup modified kernels
-    void initialize_and_backup_modified_kernels(Grid& grid);
+    // initialize and backup model update (perturbation)
+    void initialize_and_backup_model_update(Grid& grid);
 
     // check kernel value range
     void check_kernel_value_range(Grid& grid);

--- a/include/optimizer.h
+++ b/include/optimizer.h
@@ -79,7 +79,7 @@ protected:
     CUSTOMREAL grid_value_dot_product(CUSTOMREAL* vec1, CUSTOMREAL* vec2, int n);
 
     // evaluate line search performance
-    virtual bool check_conditions_for_line_search(InputParams& IP, Grid& grid, int sub_iter, int quit_sub_iter, CUSTOMREAL v_obj_inout, CUSTOMREAL v_obj_try){return false;};
+    virtual bool check_conditions_for_line_search(InputParams& IP, Grid& grid, IO_utils& io, int& i_inv, int sub_iter, int quit_sub_iter, CUSTOMREAL v_obj_inout, CUSTOMREAL v_obj_try){return false;};
 
   
 };

--- a/include/optimizer_bfgs.h
+++ b/include/optimizer_bfgs.h
@@ -59,7 +59,11 @@ private:
     void write_bfgs_gradient(Grid& grid, IO_utils& io, int& i_inv);
 
     // read bfgs gradient ()
-    void read_bfgs_gradient(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& Ks_loc, std::vector<CUSTOMREAL>& Kxi_loc, std::vector<CUSTOMREAL>& Keta_loc);
+    void read_bfgs_gradient_slowness(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& Ks_loc);
+    void read_bfgs_gradient_xi(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& Kxi_loc);
+    void read_bfgs_gradient_eta(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& Keta_loc);
+
+
 
     // calculate bfgs descent direction
     void calculate_bfgs_descent_direction(Grid& grid, IO_utils& io, int& i_inv);

--- a/include/optimizer_bfgs.h
+++ b/include/optimizer_bfgs.h
@@ -17,12 +17,13 @@ private:
     std::vector<CUSTOMREAL> array_3d_backward;
 
     // vectors in bfgs
-    std::vector<CUSTOMREAL> sk_s;       // s_k = m_{k+1} - m_k, model difference
-    std::vector<CUSTOMREAL> sk_xi;
-    std::vector<CUSTOMREAL> sk_eta;
-    std::vector<CUSTOMREAL> yk_s;       // y_k = g_{k+1} - g_k, gradient difference
-    std::vector<CUSTOMREAL> yk_xi;
-    std::vector<CUSTOMREAL> yk_eta;
+    // 20260608:  move into loop to release memory immediately after use
+    // std::vector<CUSTOMREAL> sk_s;       // s_k = m_{k+1} - m_k, model difference
+    // std::vector<CUSTOMREAL> sk_xi;
+    // std::vector<CUSTOMREAL> sk_eta;
+    // std::vector<CUSTOMREAL> yk_s;       // y_k = g_{k+1} - g_k, gradient difference
+    // std::vector<CUSTOMREAL> yk_xi;
+    // std::vector<CUSTOMREAL> yk_eta;
 
     std::vector<CUSTOMREAL> Ks_bfgs_loc;      // backup of bfgs gradient
     std::vector<CUSTOMREAL> Kxi_bfgs_loc;
@@ -64,8 +65,13 @@ private:
     void backup_bfgs_gradient(Grid& grid);
 
     // read and write histrorical model and gradient
-    void get_model_dif(Grid& grid, IO_utils& io, int& i_inv);
-    void get_gradient_dif(Grid& grid, IO_utils& io, int& i_inv);
+    void get_model_dif_slowness(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& sk_s);
+    void get_model_dif_xi(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& sk_xi);
+    void get_model_dif_eta(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& sk_eta);
+    
+    void get_gradient_dif_slowness(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& yk_s);
+    void get_gradient_dif_xi(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& yk_xi);
+    void get_gradient_dif_eta(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& yk_eta);
 
 
     // evaluate line search performance

--- a/include/optimizer_bfgs.h
+++ b/include/optimizer_bfgs.h
@@ -59,7 +59,7 @@ private:
     void write_bfgs_gradient(Grid& grid, IO_utils& io, int& i_inv);
 
     // read bfgs gradient ()
-    void read_bfgs_gradient(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& Ks_loc, std::vector<CUSTOMREAL>& Keta_loc, std::vector<CUSTOMREAL>& Kxi_loc);
+    void read_bfgs_gradient(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& Ks_loc, std::vector<CUSTOMREAL>& Kxi_loc, std::vector<CUSTOMREAL>& Keta_loc);
 
     // calculate bfgs descent direction
     void calculate_bfgs_descent_direction(Grid& grid, IO_utils& io, int& i_inv);

--- a/include/optimizer_bfgs.h
+++ b/include/optimizer_bfgs.h
@@ -25,9 +25,9 @@ private:
     // std::vector<CUSTOMREAL> yk_xi;
     // std::vector<CUSTOMREAL> yk_eta;
 
-    std::vector<CUSTOMREAL> Ks_bfgs_loc;      // backup of bfgs gradient
-    std::vector<CUSTOMREAL> Kxi_bfgs_loc;
-    std::vector<CUSTOMREAL> Keta_bfgs_loc;
+    // std::vector<CUSTOMREAL> Ks_bfgs_loc;      // backup of bfgs gradient
+    // std::vector<CUSTOMREAL> Kxi_bfgs_loc;
+    // std::vector<CUSTOMREAL> Keta_bfgs_loc;
 
     // scalars in bfgs
     std::vector<CUSTOMREAL> alpha_bfgs;  // store alpha_i in two-loop recursion
@@ -58,11 +58,14 @@ private:
     // write bfgs gradient ()
     void write_bfgs_gradient(Grid& grid, IO_utils& io, int& i_inv);
 
+    // read bfgs gradient ()
+    void read_bfgs_gradient(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& Ks_loc, std::vector<CUSTOMREAL>& Keta_loc, std::vector<CUSTOMREAL>& Kxi_loc);
+
     // calculate bfgs descent direction
     void calculate_bfgs_descent_direction(Grid& grid, IO_utils& io, int& i_inv);
 
     // backup bfgs gradient
-    void backup_bfgs_gradient(Grid& grid);
+    // void backup_bfgs_gradient(Grid& grid);
 
     // read and write histrorical model and gradient
     void get_model_dif_slowness(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& sk_s);
@@ -75,7 +78,7 @@ private:
 
 
     // evaluate line search performance
-    bool check_conditions_for_line_search(InputParams& IP, Grid& grid, int sub_iter, int quit_sub_iter, CUSTOMREAL v_obj_inout, CUSTOMREAL v_obj_try) override;
+    bool check_conditions_for_line_search(InputParams& IP, Grid& grid, IO_utils& io, int& i_inv, int sub_iter, int quit_sub_iter, CUSTOMREAL v_obj_inout, CUSTOMREAL v_obj_try) override;
 
 
 };

--- a/include/optimizer_bfgs.h
+++ b/include/optimizer_bfgs.h
@@ -13,8 +13,8 @@ private:
     const int Mbfgs = 5; // number of previous steps to store
 
     // historical model and gradient
-    std::vector<CUSTOMREAL> array_3d_forward;
-    std::vector<CUSTOMREAL> array_3d_backward;
+    // std::vector<CUSTOMREAL> array_3d_forward;
+    // std::vector<CUSTOMREAL> array_3d_backward;
 
     // vectors in bfgs
     // 20260608:  move into loop to release memory immediately after use

--- a/include/optimizer_gd.h
+++ b/include/optimizer_gd.h
@@ -23,7 +23,7 @@ private:
     void processing_kernels(InputParams& IP, Grid& grid, IO_utils& io, int& i_inv) override;
     
     // evaluate line search performance
-    bool check_conditions_for_line_search(InputParams& IP, Grid& grid, int sub_iter, int quit_sub_iter, CUSTOMREAL v_obj_inout, CUSTOMREAL v_obj_try) override;
+    bool check_conditions_for_line_search(InputParams& IP, Grid& grid, IO_utils& io, int& i_inv, int sub_iter, int quit_sub_iter, CUSTOMREAL v_obj_inout, CUSTOMREAL v_obj_try) override;
 
 };
 

--- a/src/input_params.cpp
+++ b/src/input_params.cpp
@@ -223,7 +223,6 @@ InputParams::InputParams(std::string& input_file){
                 getNodeValue(config["model_update"], "optim_method", optim_method);
                 if (optim_method > 1) {
                     std::cout << "undefined optim_method. stop." << std::endl;
-                    //MPI_Finalize();
                     exit(1);
                 }
             }
@@ -2897,6 +2896,7 @@ void InputParams::check_contradictions(){
         max_iter_inv = 1;
     }
 
+    // eikonal equation solver
     if (n_subprocs > 1 && sweep_type != SWEEP_TYPE_LEVEL){
         if(myrank == 0){
             std::cout << "Warning: n_subprocs > 1 but do not use SWEEP_TYPE_LEVEL, sweep_type changes to SWEEP_TYPE_LEVEL" << std::endl;
@@ -2923,9 +2923,17 @@ void InputParams::check_contradictions(){
             use_cs = false;
             std::cout << "use_cr_time is set to be false" << std::endl;
             use_cr = false;
-        }
-        
+        }        
     }
+
+    // line search is mandatory for lbfgs 
+    if (optim_method == LBFGS_MODE && !line_search_mode){
+        if(myrank == 0){
+            std::cout << "Warning: line search is mandatory for lbfgs, line_search_mode is set to be true" << std::endl;
+        }
+        line_search_mode = true;
+    }
+
 
 #ifdef USE_CUDA
     if (use_gpu){

--- a/src/kernel_postprocessing.cpp
+++ b/src/kernel_postprocessing.cpp
@@ -58,11 +58,11 @@ namespace Kernel_postprocessing {
     }
     
 
-    // assign processing kernels to modified kernels for model update
-    void assign_to_modified_kernels(Grid& grid){
+    // assign processing kernels to model_update for model update
+    void assign_to_model_update(Grid& grid){
         if (subdom_main){ // parallel level 3
             if (id_sim==0){ // parallel level 1
-                // assign processing kernels to modified kernels for model update
+                // assign processing kernels to model update (perturbation)
                 std::copy(grid.Ks_processing_loc.begin(), grid.Ks_processing_loc.end(), grid.Ks_update_loc);
                 std::copy(grid.Kxi_processing_loc.begin(), grid.Kxi_processing_loc.end(), grid.Kxi_update_loc);
                 std::copy(grid.Keta_processing_loc.begin(), grid.Keta_processing_loc.end(), grid.Keta_update_loc);
@@ -71,7 +71,7 @@ namespace Kernel_postprocessing {
                 std::copy(grid.Kxi_density_processing_loc.begin(), grid.Kxi_density_processing_loc.end(), grid.Kxi_density_update_loc);
                 std::copy(grid.Keta_density_processing_loc.begin(), grid.Keta_density_processing_loc.end(), grid.Keta_density_update_loc);
             }
-            // boardcast modified kernels to all simultaneous runs
+            // boardcast model_update to all simultaneous runs
             broadcast_cr_inter_sim(grid.Ks_update_loc, loc_I*loc_J*loc_K, 0);
             broadcast_cr_inter_sim(grid.Kxi_update_loc, loc_I*loc_J*loc_K, 0);
             broadcast_cr_inter_sim(grid.Keta_update_loc, loc_I*loc_J*loc_K, 0);

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -271,7 +271,7 @@ std::vector<CUSTOMREAL> Optimizer::determine_step_length_line_search(InputParams
         Kernel_postprocessing::process_kernels(IP, grid); 
 
         // substep 5, --------- evaluate the update performance ---------     
-        exit_flag = check_conditions_for_line_search(IP, grid, sub_iter, quit_sub_iter, v_obj_inout, v_obj_try);
+        exit_flag = check_conditions_for_line_search(IP, grid, io, i_inv, sub_iter, quit_sub_iter, v_obj_inout, v_obj_try);
         if(exit_flag){
             break;
         }
@@ -447,7 +447,7 @@ bool Optimizer::is_write_kernel(InputParams& IP, int& i_inv){
 CUSTOMREAL Optimizer::grid_value_dot_product(CUSTOMREAL* vec1, CUSTOMREAL* vec2, int n){
     CUSTOMREAL local_sum = dot_product(vec1, vec2, n);
     CUSTOMREAL global_sum;
-    allreduce_cr_single(local_sum, global_sum);
+    allreduce_cr_single(local_sum, global_sum);  // reduce among level 2 (multiple subdomains)
     return global_sum;
 }
 

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -31,9 +31,9 @@ std::vector<CUSTOMREAL> Optimizer::model_update(InputParams& IP, Grid& grid, IO_
     // Ks_update_loc, Keta_update_loc, Kxi_update_loc
     processing_kernels(IP, grid, io, i_inv);    // kernels have been broadcasted to all simultaneous groups 
 
-    // write out modified kernels (descent direction)
+    // write out model_update (perturbation)
     // Ks_update, Kxi_update, Keta_update, Ks_density_update, Kxi_density_update, Keta_density_update
-    write_modified_kernels(IP, grid, io, i_inv);
+    write_model_update(IP, grid, io, i_inv);
 
 
     // determine step length, and set new model
@@ -92,13 +92,13 @@ void Optimizer::write_original_kernels(InputParams& IP, Grid& grid, IO_utils& io
 void Optimizer::processing_kernels(InputParams& IP, Grid& grid, IO_utils& io, int& i_inv){}
 
 
-// write out modified kernels (descent direction)
-void Optimizer::write_modified_kernels(InputParams& IP, Grid& grid, IO_utils& io, int& i_inv){
+// write out model_update (perturbation)
+void Optimizer::write_model_update(InputParams& IP, Grid& grid, IO_utils& io, int& i_inv){
     if (is_write_kernel(IP, i_inv)) {
         // store kernel only in the first src datafile
         io.change_group_name_for_model();
 
-        // write descent direction
+        // write model_update (perturbation)
         io.write_Ks_update(grid, i_inv);
         io.write_Keta_update(grid, i_inv);
         io.write_Kxi_update(grid, i_inv);
@@ -353,22 +353,22 @@ void Optimizer::write_new_model(InputParams& IP, Grid& grid, IO_utils& io, int& 
 // ---------------------------------------------------
 
 
-// initialize and backup modified kernels
-void Optimizer::initialize_and_backup_modified_kernels(Grid& grid) {
+// initialize and backup model_update (perturbation)
+void Optimizer::initialize_and_backup_model_update(Grid& grid) {
     if (subdom_main){ // parallel level 3
         if (id_sim==0){ // parallel level 1
 
-            // initiaize and backup modified kernel (XX_update_loc) params
+            // initiaize and backup model_update (perturbation) params
             for (int k = 0; k < loc_K; k++) {
                 for (int j = 0; j < loc_J; j++) {
                     for (int i = 0; i < loc_I; i++) {
 
-                        // backup previous smoothed kernel
+                        // backup previous model_update (perturbation)
                         grid.Ks_update_loc_previous[I2V(i,j,k)]   = grid.Ks_update_loc[I2V(i,j,k)];
                         grid.Keta_update_loc_previous[I2V(i,j,k)] = grid.Keta_update_loc[I2V(i,j,k)];
                         grid.Kxi_update_loc_previous[I2V(i,j,k)]  = grid.Kxi_update_loc[I2V(i,j,k)];
 
-                        // initialize modified kernel
+                        // initialize model_update (perturbation)
                         grid.Ks_update_loc[I2V(i,j,k)]   = _0_CR;
                         grid.Keta_update_loc[I2V(i,j,k)] = _0_CR;
                         grid.Kxi_update_loc[I2V(i,j,k)]  = _0_CR;

--- a/src/optimizer_bfgs.cpp
+++ b/src/optimizer_bfgs.cpp
@@ -12,12 +12,13 @@ Optimizer_bfgs::Optimizer_bfgs(InputParams& IP) : Optimizer(IP) {
     array_3d_backward.resize(n_total_loc_grid_points);
 
     // vectors in bfgs
-    sk_s.resize(n_total_loc_grid_points);
-    sk_xi.resize(n_total_loc_grid_points);
-    sk_eta.resize(n_total_loc_grid_points);
-    yk_s.resize(n_total_loc_grid_points);
-    yk_xi.resize(n_total_loc_grid_points);
-    yk_eta.resize(n_total_loc_grid_points);
+    // 20260608:  move into loop to release memory immediately after use
+    // sk_s.resize(n_total_loc_grid_points);
+    // sk_xi.resize(n_total_loc_grid_points);
+    // sk_eta.resize(n_total_loc_grid_points);
+    // yk_s.resize(n_total_loc_grid_points);
+    // yk_xi.resize(n_total_loc_grid_points);
+    // yk_eta.resize(n_total_loc_grid_points);
 
     Ks_bfgs_loc.resize(n_total_loc_grid_points);
     Kxi_bfgs_loc.resize(n_total_loc_grid_points);
@@ -257,6 +258,22 @@ void Optimizer_bfgs::calculate_bfgs_descent_direction(Grid& grid, IO_utils& io, 
     if(subdom_main){
         if(id_sim == 0){
             if (i_inv > 0) {
+
+                // initialize vectors for two-loop recursion
+                std::vector<CUSTOMREAL> sk_s;       // s_k = m_{k+1} - m_k, model difference
+                std::vector<CUSTOMREAL> sk_xi;
+                std::vector<CUSTOMREAL> sk_eta;
+                std::vector<CUSTOMREAL> yk_s;       // y_k = g_{k+1} - g_k, gradient difference
+                std::vector<CUSTOMREAL> yk_xi;
+                std::vector<CUSTOMREAL> yk_eta;
+                
+                sk_s.resize(n_total_loc_grid_points);
+                sk_xi.resize(n_total_loc_grid_points);
+                sk_eta.resize(n_total_loc_grid_points);
+                yk_s.resize(n_total_loc_grid_points);
+                yk_xi.resize(n_total_loc_grid_points);
+                yk_eta.resize(n_total_loc_grid_points);
+
                 // --------------- step 1,  initialize q = g_k (in this step, descent_dir is q)
                 // do nothing. 
                 // grid.Ks_processing_loc is the gradient at current model
@@ -267,8 +284,12 @@ void Optimizer_bfgs::calculate_bfgs_descent_direction(Grid& grid, IO_utils& io, 
                 int n_stored = std::min(i_inv, Mbfgs);
                 for (int i_bfgs = i_inv-1; i_bfgs >= i_inv-n_stored; i_bfgs--) {
                     // --------------- substep 1, calculate rho_i = 1 / (y_i^T * s_i)
-                    get_model_dif(grid, io, i_bfgs);        // obtain s_i (model difference)
-                    get_gradient_dif(grid, io, i_bfgs);     // obtain y_i (gradient difference)
+                    get_model_dif_slowness(grid, io, i_bfgs, sk_s);        // obtain s_i (model difference)
+                    get_model_dif_xi(grid, io, i_bfgs, sk_xi);             // obtain s_i (model difference)
+                    get_model_dif_eta(grid, io, i_bfgs, sk_eta);           // obtain s_i (model difference)
+                    get_gradient_dif_slowness(grid, io, i_bfgs, yk_s);     // obtain y_i (gradient difference)
+                    get_gradient_dif_xi(grid, io, i_bfgs, yk_xi);          // obtain y_i (gradient difference)
+                    get_gradient_dif_eta(grid, io, i_bfgs, yk_eta);        // obtain y_i (gradient difference)
                     rho[i_bfgs]     = grid_value_dot_product(yk_s.data(), sk_s.data(), n_total_loc_grid_points);      // for slowness
                     rho[i_bfgs]    += grid_value_dot_product(yk_xi.data(), sk_xi.data(), n_total_loc_grid_points);   // for xi
                     rho[i_bfgs]    += grid_value_dot_product(yk_eta.data(), sk_eta.data(), n_total_loc_grid_points);  // for eta
@@ -292,8 +313,12 @@ void Optimizer_bfgs::calculate_bfgs_descent_direction(Grid& grid, IO_utils& io, 
                 // --------------- step 3, scaling of initial Hessian H0_k  (in this step, descent_dir is z)
                 // substep 1, calculate gamma_k = (s_{k-1}^T * y_{k-1}) / (y_{k-1}^T * y_{k-1})
                 int i_bfgs = i_inv - 1;
-                get_model_dif(grid, io, i_bfgs);     // obtain s_{k-1} (model difference)
-                get_gradient_dif(grid, io, i_bfgs);  // obtain y_{k-1} (gradient difference)
+                get_model_dif_slowness(grid, io, i_bfgs, sk_s);     // obtain s_{k-1} (model difference)
+                get_model_dif_xi(grid, io, i_bfgs, sk_xi);          // obtain s_{k-1} (model difference)
+                get_model_dif_eta(grid, io, i_bfgs, sk_eta);        // obtain s_{k-1} (model difference)
+                get_gradient_dif_slowness(grid, io, i_bfgs, yk_s);  // obtain y_{k-1} (gradient difference)
+                get_gradient_dif_xi(grid, io, i_bfgs, yk_xi);       // obtain y_{k-1} (gradient difference)
+                get_gradient_dif_eta(grid, io, i_bfgs, yk_eta);     // obtain y_{k-1} (gradient difference)
                 CUSTOMREAL sT_y = _0_CR;
                 sT_y  = grid_value_dot_product(sk_s.data(), yk_s.data(), n_total_loc_grid_points);
                 sT_y += grid_value_dot_product(sk_xi.data(), yk_xi.data(), n_total_loc_grid_points);
@@ -314,7 +339,9 @@ void Optimizer_bfgs::calculate_bfgs_descent_direction(Grid& grid, IO_utils& io, 
                 // --------------- step 4, loop for i = k-Mbfgs, k-Mbfgs+1, ..., k-1  (in this step, descent_dir is z)
                 for (int i_bfgs = i_inv-n_stored; i_bfgs <= i_inv-1; i_bfgs++) {
                     // --------------- substep 1, beta = rho_i * y_i^T * z
-                    get_gradient_dif(grid, io, i_bfgs); // obtain y_i (gradient difference)
+                    get_gradient_dif_slowness(grid, io, i_bfgs, yk_s); // obtain y_i (gradient difference)
+                    get_gradient_dif_xi(grid, io, i_bfgs, yk_xi);       // obtain y_i (gradient difference)
+                    get_gradient_dif_eta(grid, io, i_bfgs, yk_eta);     // obtain y_i (gradient difference)
                     CUSTOMREAL beta = _0_CR;
                     beta  = grid_value_dot_product(yk_s.data(), grid.Ks_processing_loc.data(), n_total_loc_grid_points);
                     beta += grid_value_dot_product(yk_xi.data(), grid.Kxi_processing_loc.data(), n_total_loc_grid_points);
@@ -322,7 +349,9 @@ void Optimizer_bfgs::calculate_bfgs_descent_direction(Grid& grid, IO_utils& io, 
                     beta *= rho[i_bfgs];
 
                     // --------------- substep 2, z = z + s_i * (alpha_i - beta)
-                    get_model_dif(grid, io, i_bfgs);     // obtain s_i (model difference)
+                    get_model_dif_slowness(grid, io, i_bfgs, sk_s);     // obtain s_i (model difference)
+                    get_model_dif_xi(grid, io, i_bfgs, sk_xi);          // obtain s_i (model difference)
+                    get_model_dif_eta(grid, io, i_bfgs, sk_eta);        // obtain s_i (model difference)
                     for (int idx = 0; idx < n_total_loc_grid_points; idx++) {
                         grid.Ks_processing_loc[idx]   += sk_s[idx] * (alpha_bfgs[i_bfgs] - beta);
                         grid.Kxi_processing_loc[idx]  += sk_xi[idx] * (alpha_bfgs[i_bfgs] - beta);
@@ -374,7 +403,7 @@ void Optimizer_bfgs::backup_bfgs_gradient(Grid& grid){
 
 
 // read histrorical model difference
-void Optimizer_bfgs::get_model_dif(Grid& grid, IO_utils& io, int& i_inv){
+void Optimizer_bfgs::get_model_dif_slowness(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& sk_s){
     // make h5_group_name_data to be "model"
     io.change_group_name_for_model();
 
@@ -385,7 +414,12 @@ void Optimizer_bfgs::get_model_dif(Grid& grid, IO_utils& io, int& i_inv){
     grid.set_array_from_vis(array_3d_backward.data());
     for (int i = 0; i < n_total_loc_grid_points; i++)
         sk_s[i] = std::log(1.0/array_3d_forward[i]) - std::log(1.0/array_3d_backward[i]);
-    
+}
+
+void Optimizer_bfgs::get_model_dif_xi(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& sk_xi){
+    // make h5_group_name_data to be "model"
+    io.change_group_name_for_model();
+
     // delta xi
     io.read_xi(grid, i_inv + 1);
     grid.set_array_from_vis(array_3d_forward.data());
@@ -393,6 +427,11 @@ void Optimizer_bfgs::get_model_dif(Grid& grid, IO_utils& io, int& i_inv){
     grid.set_array_from_vis(array_3d_backward.data());
     for (int i = 0; i < n_total_loc_grid_points; i++)
         sk_xi[i] = array_3d_forward[i] - array_3d_backward[i];
+}
+
+void Optimizer_bfgs::get_model_dif_eta(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& sk_eta){
+    // make h5_group_name_data to be "model"
+    io.change_group_name_for_model();
 
     // delta eta
     io.read_eta(grid, i_inv + 1);
@@ -405,7 +444,7 @@ void Optimizer_bfgs::get_model_dif(Grid& grid, IO_utils& io, int& i_inv){
 
 
 // read histrorical gradient difference
-void Optimizer_bfgs::get_gradient_dif(Grid& grid, IO_utils& io, int& i_inv){
+void Optimizer_bfgs::get_gradient_dif_slowness(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& yk_s){
     // make h5_group_name_data to be "model"
     io.change_group_name_for_model();
 
@@ -416,6 +455,11 @@ void Optimizer_bfgs::get_gradient_dif(Grid& grid, IO_utils& io, int& i_inv){
     grid.set_array_from_vis(array_3d_backward.data());
     for (int i = 0; i < n_total_loc_grid_points; i++)
         yk_s[i] = array_3d_forward[i] - array_3d_backward[i];
+}
+
+void Optimizer_bfgs::get_gradient_dif_xi(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& yk_xi){
+    // make h5_group_name_data to be "model"
+    io.change_group_name_for_model();
 
     // xi gradient difference
     io.read_Kxi_bfgs(grid, i_inv + 1);
@@ -424,7 +468,12 @@ void Optimizer_bfgs::get_gradient_dif(Grid& grid, IO_utils& io, int& i_inv){
     grid.set_array_from_vis(array_3d_backward.data());
     for (int i = 0; i < n_total_loc_grid_points; i++)
         yk_xi[i] = array_3d_forward[i] - array_3d_backward[i];
-        
+}
+
+void Optimizer_bfgs::get_gradient_dif_eta(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& yk_eta){
+    // make h5_group_name_data to be "model"
+    io.change_group_name_for_model();
+
     // eta gradient difference
     io.read_Keta_bfgs(grid, i_inv + 1);
     grid.set_array_from_vis(array_3d_forward.data());

--- a/src/optimizer_bfgs.cpp
+++ b/src/optimizer_bfgs.cpp
@@ -20,9 +20,12 @@ Optimizer_bfgs::Optimizer_bfgs(InputParams& IP) : Optimizer(IP) {
     // yk_xi.resize(n_total_loc_grid_points);
     // yk_eta.resize(n_total_loc_grid_points);
 
-    Ks_bfgs_loc.resize(n_total_loc_grid_points);
-    Kxi_bfgs_loc.resize(n_total_loc_grid_points);
-    Keta_bfgs_loc.resize(n_total_loc_grid_points);
+    // backup of bfgs gradient
+    // 20260608:  move to backup_bfgs_gradient to load array
+    //        and move to 
+    // Ks_bfgs_loc.resize(n_total_loc_grid_points);
+    // Kxi_bfgs_loc.resize(n_total_loc_grid_points);
+    // Keta_bfgs_loc.resize(n_total_loc_grid_points);
 
     // scalars in bfgs
     alpha_bfgs.resize(10000);
@@ -49,8 +52,8 @@ Optimizer_bfgs::~Optimizer_bfgs() {
 // smooth kernels (multigrid) + kernel normalization (kernel density normalization)
 void Optimizer_bfgs::processing_kernels(InputParams& IP, Grid& grid, IO_utils& io, int& i_inv) {
     
-    // initialize and backup modified kernels
-    initialize_and_backup_modified_kernels(grid);
+    // initialize and backup model_update (perturbation)
+    initialize_and_backup_model_update(grid);
 
     // check kernel value range
     check_kernel_value_range(grid);
@@ -61,10 +64,11 @@ void Optimizer_bfgs::processing_kernels(InputParams& IP, Grid& grid, IO_utils& i
     // Ks_processing_loc, Keta_processing_loc, Kxi_processing_loc
     Kernel_postprocessing::process_kernels(IP, grid); 
 
-    // write bfgs gradient
+    // write bfgs gradient (Ks_processing_loc, Keta_processing_loc, Kxi_processing_loc)
     write_bfgs_gradient(grid, io, i_inv);
 
-    // backup bfgs gradient
+    // backup bfgs gradient (backup the gradient at k-th model)
+    // backup bfgs gradient (Ks_processing_loc, Keta_processing_loc, Kxi_processing_loc) to Ks_bfgs_loc, Keta_bfgs_loc, Kxi_bfgs_loc
     backup_bfgs_gradient(grid);
     
     // calculate bfgs descent direction
@@ -73,11 +77,11 @@ void Optimizer_bfgs::processing_kernels(InputParams& IP, Grid& grid, IO_utils& i
     // normalize kernels to -1 ~ 1
     Kernel_postprocessing::normalize_kernels(grid);
     
-    // assign processing kernels to modified kernels for model update
+    // assign processing kernels to model_update (perturbation)
     // Ks_processing_loc, Keta_processing_loc, Kxi_processing_loc
     // -->
     // Ks_update_loc, Keta_update_loc, Kxi_update_loc
-    Kernel_postprocessing::assign_to_modified_kernels(grid);
+    Kernel_postprocessing::assign_to_model_update(grid);
 }
 
 
@@ -382,7 +386,7 @@ void Optimizer_bfgs::write_bfgs_gradient(Grid& grid, IO_utils& io, int& i_inv){
         // store kernel only in the first src datafile
         io.change_group_name_for_model();
 
-        // write descent direction
+        // write descent direction (Ks_processing_loc, Keta_processing_loc, Kxi_processing_loc)
         io.write_Ks_bfgs(grid, i_inv);
         io.write_Keta_bfgs(grid, i_inv);
         io.write_Kxi_bfgs(grid, i_inv);

--- a/src/optimizer_bfgs.cpp
+++ b/src/optimizer_bfgs.cpp
@@ -128,7 +128,10 @@ bool Optimizer_bfgs::check_conditions_for_line_search(InputParams& IP, Grid& gri
             Keta_bfgs_loc.resize(n_total_loc_grid_points);
 
             // read bfgs gradient at current model = g_k, that is, grad_f(x_k)
-            read_bfgs_gradient(grid, io, i_inv, Ks_bfgs_loc, Kxi_bfgs_loc, Keta_bfgs_loc);
+            read_bfgs_gradient_slowness(grid, io, i_inv, Ks_bfgs_loc);
+            read_bfgs_gradient_xi(grid, io, i_inv, Kxi_bfgs_loc);
+            read_bfgs_gradient_eta(grid, io, i_inv, Keta_bfgs_loc);
+            
 
             // Ks_update_loc is -p = - alpha * (m_k+1 - m_k)
             // Ks_bfgs_loc is the backup of gradient at current model = g_k, that is, grad_f(x_k)
@@ -410,7 +413,7 @@ void Optimizer_bfgs::write_bfgs_gradient(Grid& grid, IO_utils& io, int& i_inv){
     }
 }
 
-void Optimizer_bfgs::read_bfgs_gradient(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& Ks_bfgs_loc, std::vector<CUSTOMREAL>& Kxi_bfgs_loc, std::vector<CUSTOMREAL>& Keta_bfgs_loc){
+void Optimizer_bfgs::read_bfgs_gradient_slowness(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& Ks_bfgs_loc){
     if (id_sim == 0 && subdom_main){
         // store kernel only in the first src datafile
         io.change_group_name_for_model();
@@ -418,10 +421,26 @@ void Optimizer_bfgs::read_bfgs_gradient(Grid& grid, IO_utils& io, int& i_inv, st
         // write descent direction (Ks_processing_loc, Keta_processing_loc, Kxi_processing_loc)
         io.read_Ks_bfgs(grid, i_inv);
         grid.set_array_from_vis(Ks_bfgs_loc.data());
-        
+    }
+}
+
+void Optimizer_bfgs::read_bfgs_gradient_xi(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& Kxi_bfgs_loc){
+    if (id_sim == 0 && subdom_main){
+        // store kernel only in the first src datafile
+        io.change_group_name_for_model();
+
+        // write descent direction (Ks_processing_loc, Keta_processing_loc, Kxi_processing_loc)
         io.read_Kxi_bfgs(grid, i_inv);
         grid.set_array_from_vis(Kxi_bfgs_loc.data());
+    }
+}
 
+void Optimizer_bfgs::read_bfgs_gradient_eta(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& Keta_bfgs_loc){
+    if (id_sim == 0 && subdom_main){
+        // store kernel only in the first src datafile
+        io.change_group_name_for_model();
+
+        // write descent direction (Ks_processing_loc, Keta_processing_loc, Kxi_processing_loc)
         io.read_Keta_bfgs(grid, i_inv);
         grid.set_array_from_vis(Keta_bfgs_loc.data());
     }

--- a/src/optimizer_bfgs.cpp
+++ b/src/optimizer_bfgs.cpp
@@ -128,7 +128,7 @@ bool Optimizer_bfgs::check_conditions_for_line_search(InputParams& IP, Grid& gri
             Keta_bfgs_loc.resize(n_total_loc_grid_points);
 
             // read bfgs gradient at current model = g_k, that is, grad_f(x_k)
-            read_bfgs_gradient(grid, io, i_inv, Ks_bfgs_loc, Keta_bfgs_loc, Kxi_bfgs_loc);
+            read_bfgs_gradient(grid, io, i_inv, Ks_bfgs_loc, Kxi_bfgs_loc, Keta_bfgs_loc);
 
             // Ks_update_loc is -p = - alpha * (m_k+1 - m_k)
             // Ks_bfgs_loc is the backup of gradient at current model = g_k, that is, grad_f(x_k)
@@ -418,10 +418,12 @@ void Optimizer_bfgs::read_bfgs_gradient(Grid& grid, IO_utils& io, int& i_inv, st
         // write descent direction (Ks_processing_loc, Keta_processing_loc, Kxi_processing_loc)
         io.read_Ks_bfgs(grid, i_inv);
         grid.set_array_from_vis(Ks_bfgs_loc.data());
-        io.read_Keta_bfgs(grid, i_inv);
-        grid.set_array_from_vis(Keta_bfgs_loc.data());
+        
         io.read_Kxi_bfgs(grid, i_inv);
         grid.set_array_from_vis(Kxi_bfgs_loc.data());
+
+        io.read_Keta_bfgs(grid, i_inv);
+        grid.set_array_from_vis(Keta_bfgs_loc.data());
     }
 }
 

--- a/src/optimizer_bfgs.cpp
+++ b/src/optimizer_bfgs.cpp
@@ -8,8 +8,8 @@ Optimizer_bfgs::Optimizer_bfgs(InputParams& IP) : Optimizer(IP) {
     need_write_original_kernel = true;
 
     // initialize sizes
-    array_3d_forward.resize(n_total_loc_grid_points);
-    array_3d_backward.resize(n_total_loc_grid_points);
+    // array_3d_forward.resize(n_total_loc_grid_points);
+    // array_3d_backward.resize(n_total_loc_grid_points);
 
     // vectors in bfgs
     // 20260608:  move into loop to release memory immediately after use
@@ -448,11 +448,15 @@ void Optimizer_bfgs::get_model_dif_slowness(Grid& grid, IO_utils& io, int& i_inv
 
     // slowness perturbation, delta ln(1/vel)
     io.read_vel(grid, i_inv + 1);
-    grid.set_array_from_vis(array_3d_forward.data());
+    grid.set_array_from_vis(sk_s.data());   // temporary use sk_s to store model at k+1
+
+    std::vector<CUSTOMREAL> array_3d_backward;
+    array_3d_backward.resize(n_total_loc_grid_points);
     io.read_vel(grid, i_inv);
     grid.set_array_from_vis(array_3d_backward.data());
+
     for (int i = 0; i < n_total_loc_grid_points; i++)
-        sk_s[i] = std::log(1.0/array_3d_forward[i]) - std::log(1.0/array_3d_backward[i]);
+        sk_s[i] = std::log(1.0/sk_s[i]) - std::log(1.0/array_3d_backward[i]);   
 }
 
 void Optimizer_bfgs::get_model_dif_xi(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& sk_xi){
@@ -461,11 +465,15 @@ void Optimizer_bfgs::get_model_dif_xi(Grid& grid, IO_utils& io, int& i_inv, std:
 
     // delta xi
     io.read_xi(grid, i_inv + 1);
-    grid.set_array_from_vis(array_3d_forward.data());
+    grid.set_array_from_vis(sk_xi.data());   // temporary use sk_xi to store model at k+1
+
+    std::vector<CUSTOMREAL> array_3d_backward;
+    array_3d_backward.resize(n_total_loc_grid_points);
     io.read_xi(grid, i_inv);
     grid.set_array_from_vis(array_3d_backward.data());
+
     for (int i = 0; i < n_total_loc_grid_points; i++)
-        sk_xi[i] = array_3d_forward[i] - array_3d_backward[i];
+        sk_xi[i] = sk_xi[i] - array_3d_backward[i];
 }
 
 void Optimizer_bfgs::get_model_dif_eta(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& sk_eta){
@@ -474,11 +482,15 @@ void Optimizer_bfgs::get_model_dif_eta(Grid& grid, IO_utils& io, int& i_inv, std
 
     // delta eta
     io.read_eta(grid, i_inv + 1);
-    grid.set_array_from_vis(array_3d_forward.data());
+    grid.set_array_from_vis(sk_eta.data());   // temporary use sk_eta to store model at k+1
+
+    std::vector<CUSTOMREAL> array_3d_backward;
+    array_3d_backward.resize(n_total_loc_grid_points);
     io.read_eta(grid, i_inv);
     grid.set_array_from_vis(array_3d_backward.data());
+
     for (int i = 0; i < n_total_loc_grid_points; i++)
-        sk_eta[i] = array_3d_forward[i] - array_3d_backward[i];
+        sk_eta[i] = sk_eta[i] - array_3d_backward[i];
 }
 
 
@@ -489,11 +501,15 @@ void Optimizer_bfgs::get_gradient_dif_slowness(Grid& grid, IO_utils& io, int& i_
 
     // slowness gradient difference
     io.read_Ks_bfgs(grid, i_inv + 1);
-    grid.set_array_from_vis(array_3d_forward.data());
+    grid.set_array_from_vis(yk_s.data());   // temporary use yk_s to store gradient at k+1
+
+    std::vector<CUSTOMREAL> array_3d_backward;
+    array_3d_backward.resize(n_total_loc_grid_points);
     io.read_Ks_bfgs(grid, i_inv);
     grid.set_array_from_vis(array_3d_backward.data());
+
     for (int i = 0; i < n_total_loc_grid_points; i++)
-        yk_s[i] = array_3d_forward[i] - array_3d_backward[i];
+        yk_s[i] = yk_s[i] - array_3d_backward[i];
 }
 
 void Optimizer_bfgs::get_gradient_dif_xi(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& yk_xi){
@@ -502,11 +518,15 @@ void Optimizer_bfgs::get_gradient_dif_xi(Grid& grid, IO_utils& io, int& i_inv, s
 
     // xi gradient difference
     io.read_Kxi_bfgs(grid, i_inv + 1);
-    grid.set_array_from_vis(array_3d_forward.data());
+    grid.set_array_from_vis(yk_xi.data());   // temporary use yk_xi to store gradient at k+1
+
+    std::vector<CUSTOMREAL> array_3d_backward;
+    array_3d_backward.resize(n_total_loc_grid_points);
     io.read_Kxi_bfgs(grid, i_inv);
     grid.set_array_from_vis(array_3d_backward.data());
+
     for (int i = 0; i < n_total_loc_grid_points; i++)
-        yk_xi[i] = array_3d_forward[i] - array_3d_backward[i];
+        yk_xi[i] = yk_xi[i] - array_3d_backward[i];
 }
 
 void Optimizer_bfgs::get_gradient_dif_eta(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& yk_eta){
@@ -515,11 +535,15 @@ void Optimizer_bfgs::get_gradient_dif_eta(Grid& grid, IO_utils& io, int& i_inv, 
 
     // eta gradient difference
     io.read_Keta_bfgs(grid, i_inv + 1);
-    grid.set_array_from_vis(array_3d_forward.data());
+    grid.set_array_from_vis(yk_eta.data());   // temporary use yk_eta to store gradient at k+1
+
+    std::vector<CUSTOMREAL> array_3d_backward;
+    array_3d_backward.resize(n_total_loc_grid_points);
     io.read_Keta_bfgs(grid, i_inv);
-    grid.set_array_from_vis(array_3d_backward.data());
+    grid.set_array_from_vis(array_3d_backward.data());  
+
     for (int i = 0; i < n_total_loc_grid_points; i++)
-        yk_eta[i] = array_3d_forward[i] - array_3d_backward[i];
+        yk_eta[i] = yk_eta[i] - array_3d_backward[i];
 }
 
 

--- a/src/optimizer_bfgs.cpp
+++ b/src/optimizer_bfgs.cpp
@@ -67,9 +67,10 @@ void Optimizer_bfgs::processing_kernels(InputParams& IP, Grid& grid, IO_utils& i
     // write bfgs gradient (Ks_processing_loc, Keta_processing_loc, Kxi_processing_loc)
     write_bfgs_gradient(grid, io, i_inv);
 
+    // 20260608: no need to backup, choose to read
     // backup bfgs gradient (backup the gradient at k-th model)
     // backup bfgs gradient (Ks_processing_loc, Keta_processing_loc, Kxi_processing_loc) to Ks_bfgs_loc, Keta_bfgs_loc, Kxi_bfgs_loc
-    backup_bfgs_gradient(grid);
+    // backup_bfgs_gradient(grid);
     
     // calculate bfgs descent direction
     calculate_bfgs_descent_direction(grid, io, i_inv);
@@ -87,7 +88,7 @@ void Optimizer_bfgs::processing_kernels(InputParams& IP, Grid& grid, IO_utils& i
 
 // evaluate line search performance
 // (to do) allow users to adjust the step length change
-bool Optimizer_bfgs::check_conditions_for_line_search(InputParams& IP, Grid& grid, int sub_iter, int quit_sub_iter, CUSTOMREAL v_obj_inout, CUSTOMREAL v_obj_try){
+bool Optimizer_bfgs::check_conditions_for_line_search(InputParams& IP, Grid& grid, IO_utils& io, int& i_inv, int sub_iter, int quit_sub_iter, CUSTOMREAL v_obj_inout, CUSTOMREAL v_obj_try){
     bool exit_flag = false;
 
     // --------------- Armijo condition, sufficient decrease condition (modified) ---------------
@@ -116,23 +117,38 @@ bool Optimizer_bfgs::check_conditions_for_line_search(InputParams& IP, Grid& gri
     bool cond_curvature = false;
     CUSTOMREAL proj_current = _0_CR;   // grad_f(x_k)^T * p_k, projection of gradient on descent direction at current model
     CUSTOMREAL proj_tried = _0_CR;   // grad_f(x_k+1)^T * p_k, projection of gradient on descent direction at tried model
-    if (subdom_main){    // check condition only for main of level 3
-        // Ks_update_loc is -p = - alpha * (m_k+1 - m_k)
-        // Ks_bfgs_loc is the backup of gradient at current model = g_k, that is, grad_f(x_k)
-        proj_current -= grid_value_dot_product(grid.Ks_update_loc, Ks_bfgs_loc.data(), n_total_loc_grid_points);
-        proj_current -= grid_value_dot_product(grid.Kxi_update_loc, Kxi_bfgs_loc.data(), n_total_loc_grid_points);
-        proj_current -= grid_value_dot_product(grid.Keta_update_loc, Keta_bfgs_loc.data(), n_total_loc_grid_points);
+    if (subdom_main){    // check condition only for main of level 3 
+        if (id_sim == 0){  // only check by the first simul group
+            // Ks_bfgs_loc is the backup of gradient at current model = g_k, that is, grad_f(x_k)
+            std::vector<CUSTOMREAL> Ks_bfgs_loc;      
+            std::vector<CUSTOMREAL> Kxi_bfgs_loc;
+            std::vector<CUSTOMREAL> Keta_bfgs_loc;
+            Ks_bfgs_loc.resize(n_total_loc_grid_points);
+            Kxi_bfgs_loc.resize(n_total_loc_grid_points);
+            Keta_bfgs_loc.resize(n_total_loc_grid_points);
 
-        // Ks_processing_loc is gradient at tried model = g_k+1 = grad_f(x_k+1)
-        proj_tried -= grid_value_dot_product(grid.Ks_update_loc, grid.Ks_processing_loc.data(), n_total_loc_grid_points);
-        proj_tried -= grid_value_dot_product(grid.Kxi_update_loc, grid.Kxi_processing_loc.data(), n_total_loc_grid_points);
-        proj_tried -= grid_value_dot_product(grid.Keta_update_loc, grid.Keta_processing_loc.data(), n_total_loc_grid_points);
+            // read bfgs gradient at current model = g_k, that is, grad_f(x_k)
+            read_bfgs_gradient(grid, io, i_inv, Ks_bfgs_loc, Keta_bfgs_loc, Kxi_bfgs_loc);
 
-        if (proj_tried >= proj_current){
-            cond_curvature = true;
+            // Ks_update_loc is -p = - alpha * (m_k+1 - m_k)
+            // Ks_bfgs_loc is the backup of gradient at current model = g_k, that is, grad_f(x_k)
+            proj_current -= grid_value_dot_product(grid.Ks_update_loc, Ks_bfgs_loc.data(), n_total_loc_grid_points);
+            proj_current -= grid_value_dot_product(grid.Kxi_update_loc, Kxi_bfgs_loc.data(), n_total_loc_grid_points);
+            proj_current -= grid_value_dot_product(grid.Keta_update_loc, Keta_bfgs_loc.data(), n_total_loc_grid_points);
+
+            // Ks_processing_loc is gradient at tried model = g_k+1 = grad_f(x_k+1)
+            proj_tried -= grid_value_dot_product(grid.Ks_update_loc, grid.Ks_processing_loc.data(), n_total_loc_grid_points);
+            proj_tried -= grid_value_dot_product(grid.Kxi_update_loc, grid.Kxi_processing_loc.data(), n_total_loc_grid_points);
+            proj_tried -= grid_value_dot_product(grid.Keta_update_loc, grid.Keta_processing_loc.data(), n_total_loc_grid_points);
+
+            if (proj_tried >= proj_current){
+                cond_curvature = true;
+            }
         }
+        // level 1 commun
+        broadcast_bool_single_inter_sim(cond_curvature, 0);       
     }
-    //  broadcast the condition result to all processes within one subdomain
+    //  (level 3, within one subdomain (the main subdomain)) broadcast the condition result to all processes within one subdomain
     broadcast_bool_single_sub(cond_curvature, 0);       // '_sub' means within one subdomain, subdom_main tell others
 
 
@@ -371,6 +387,7 @@ void Optimizer_bfgs::calculate_bfgs_descent_direction(Grid& grid, IO_utils& io, 
             }
         }
 
+        // level 1, communication
         broadcast_cr_inter_sim(grid.Ks_processing_loc.data(), loc_I*loc_J*loc_K, 0);
         broadcast_cr_inter_sim(grid.Kxi_processing_loc.data(), loc_I*loc_J*loc_K, 0);
         broadcast_cr_inter_sim(grid.Keta_processing_loc.data(), loc_I*loc_J*loc_K, 0);
@@ -393,17 +410,33 @@ void Optimizer_bfgs::write_bfgs_gradient(Grid& grid, IO_utils& io, int& i_inv){
     }
 }
 
+void Optimizer_bfgs::read_bfgs_gradient(Grid& grid, IO_utils& io, int& i_inv, std::vector<CUSTOMREAL>& Ks_bfgs_loc, std::vector<CUSTOMREAL>& Kxi_bfgs_loc, std::vector<CUSTOMREAL>& Keta_bfgs_loc){
+    if (id_sim == 0 && subdom_main){
+        // store kernel only in the first src datafile
+        io.change_group_name_for_model();
+
+        // write descent direction (Ks_processing_loc, Keta_processing_loc, Kxi_processing_loc)
+        io.read_Ks_bfgs(grid, i_inv);
+        grid.set_array_from_vis(Ks_bfgs_loc.data());
+        io.read_Keta_bfgs(grid, i_inv);
+        grid.set_array_from_vis(Keta_bfgs_loc.data());
+        io.read_Kxi_bfgs(grid, i_inv);
+        grid.set_array_from_vis(Kxi_bfgs_loc.data());
+    }
+}
+
+
 
 // backup bfgs gradient
-void Optimizer_bfgs::backup_bfgs_gradient(Grid& grid){
-    if (subdom_main){
-        // backup bfgs gradient
-        Ks_bfgs_loc = grid.Ks_processing_loc;
-        Kxi_bfgs_loc = grid.Kxi_processing_loc;
-        Keta_bfgs_loc = grid.Keta_processing_loc;
-    }
-    synchronize_all_world();
-}
+// void Optimizer_bfgs::backup_bfgs_gradient(Grid& grid){
+//     if (subdom_main){
+//         // backup bfgs gradient
+//         Ks_bfgs_loc = grid.Ks_processing_loc;
+//         Kxi_bfgs_loc = grid.Kxi_processing_loc;
+//         Keta_bfgs_loc = grid.Keta_processing_loc;
+//     }
+//     synchronize_all_world();
+// }
 
 
 // read histrorical model difference

--- a/src/optimizer_gd.cpp
+++ b/src/optimizer_gd.cpp
@@ -25,8 +25,8 @@ Optimizer_gd::~Optimizer_gd() {
 // smooth kernels (multigrid) + kernel normalization (kernel density normalization)
 void Optimizer_gd::processing_kernels(InputParams& IP, Grid& grid, IO_utils& io, int& i_inv) {
     
-    // initialize and backup modified kernels
-    initialize_and_backup_modified_kernels(grid);
+    // initialize and backup model_update (perturbation)
+    initialize_and_backup_model_update(grid);
 
     // check kernel value range
     check_kernel_value_range(grid);
@@ -40,11 +40,11 @@ void Optimizer_gd::processing_kernels(InputParams& IP, Grid& grid, IO_utils& io,
     // 2. normalize kernels to -1 ~ 1
     Kernel_postprocessing::normalize_kernels(grid);
 
-    // assign to modified kernels
+    // assign to model_update
     // Ks_processing_loc, Keta_processing_loc, Kxi_processing_loc
     // -->
     // Ks_update_loc, Keta_update_loc, Kxi_update_loc
-    Kernel_postprocessing::assign_to_modified_kernels(grid);
+    Kernel_postprocessing::assign_to_model_update(grid);
 }
 
 

--- a/src/optimizer_gd.cpp
+++ b/src/optimizer_gd.cpp
@@ -49,7 +49,7 @@ void Optimizer_gd::processing_kernels(InputParams& IP, Grid& grid, IO_utils& io,
 
 
 // evaluate line search performance
-bool Optimizer_gd::check_conditions_for_line_search(InputParams& IP, Grid& grid, int sub_iter, int quit_sub_iter, CUSTOMREAL v_obj_inout, CUSTOMREAL v_obj_try){
+bool Optimizer_gd::check_conditions_for_line_search(InputParams& IP, Grid& grid, IO_utils& io, int& i_inv, int sub_iter, int quit_sub_iter, CUSTOMREAL v_obj_inout, CUSTOMREAL v_obj_try){
     // There are 8 ways to adjust step:
     // The current model: (step, obj) = (0, v_obj_inout)
     // The first try: (alpha, v1)

--- a/tests/backup_functions/model_optimization_routines.h
+++ b/tests/backup_functions/model_optimization_routines.h
@@ -51,7 +51,7 @@ inline void model_optimize(InputParams& IP, Grid& grid, IO_utils& io, int i_inv,
     // smooth kernels (multigrid, and kdensity normalization)
     smooth_kernels(grid, IP);
 
-    // write out modified kernels
+    // write out model_update (perturbation)
     if (id_sim==0 && subdom_main && IP.get_if_output_kernel() && (IP.get_if_output_in_process() || i_inv >= IP.get_max_iter_inv() - 2 || i_inv == 0)) {
         // store kernel only in the first src datafile
         io.change_group_name_for_model();


### PR DESCRIPTION
optimize the ram usage in bfgs. A small example shows that, ram usage reduced from 0.370235_GB to 0.342228 GB, for a grid of 61 by 61 by 61