### PR TITLE
simplify datainfo to reduce RAM

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -147,6 +147,11 @@ inline      bool hybrid_stencil_order = false; // if true, code at first run 1st
 inline const int NON_UPWIND = 0;
 inline const int UPWIND     = 1;
 
+// DATA TYPE FLAG
+inline const int DATA_TYPE_ABS      = 0;
+inline const int DATA_TYPE_CSDIF    = 1;
+inline const int DATA_TYPE_CRDIF    = 2;
+
 // convert depth <-> radius
 inline CUSTOMREAL depth2radius(CUSTOMREAL depth) {
     return R_earth - depth;

--- a/include/input_params.h
+++ b/include/input_params.h
@@ -467,9 +467,9 @@ private:
 // utils
 //
 inline DataInfo& get_data_src_rec(std::vector<DataInfo>& v){
-    // return the first element in the vector with is_rec_pair = true
+    // return the first element in the vector with data_type == DATA_TYPE_ABS
     for (auto it = v.begin(); it != v.end(); it++){
-        if (it->is_src_rec)
+        if (it->data_type == DATA_TYPE_ABS)
             return *it;
     }
 
@@ -486,17 +486,17 @@ inline DataInfo& get_data_rec_pair(std::map<std::string, std::map<std::string, s
                                    const std::string& name_src,
                                    const std::string& name_rec1,
                                    const std::string& name_rec2){
-    // return the first element in the vector with is_rec_pair = true
+    // return the first element in the vector with data_type == DATA_TYPE_CSDIF
     auto& map1 = v[name_src][name_rec1];
     auto& map2 = v[name_src][name_rec2];
 
     for (auto it = map1.begin(); it != map1.end(); it++){
-        if (it->is_rec_pair && it->name_rec_pair[0] == name_rec1 && it->name_rec_pair[1] == name_rec2)
+        if (it->data_type == DATA_TYPE_CSDIF && it->name_rec_pair[0] == name_rec1 && it->name_rec_pair[1] == name_rec2)
             return *it;
     }
 
     for (auto it = map2.begin(); it != map2.end(); it++){
-        if (it->is_rec_pair && it->name_rec_pair[0] == name_rec1 && it->name_rec_pair[1] == name_rec2)
+        if (it->data_type == DATA_TYPE_CSDIF && it->name_rec_pair[0] == name_rec2 && it->name_rec_pair[1] == name_rec1)
             return *it;
     }
 
@@ -514,17 +514,17 @@ inline DataInfo& get_data_src_pair(std::map<std::string, std::map<std::string, s
                                    const std::string& name_src2,
                                    const std::string& name_rec){
 
-    // return the first element in the vector with is_rec_pair = true
+    // return the first element in the vector with data_type == DATA_TYPE_CRDIF
     auto& map1 = v[name_src1][name_rec];
     auto& map2 = v[name_src2][name_rec];
 
     for (auto it = map1.begin(); it != map1.end(); it++){
-        if (it->is_src_pair && it->name_src_pair[0] == name_src1 && it->name_src_pair[1] == name_src2)
+        if (it->data_type == DATA_TYPE_CRDIF && it->name_src_pair[0] == name_src1 && it->name_src_pair[1] == name_src2)
             return *it;
     }
 
     for (auto it = map2.begin(); it != map2.end(); it++){
-        if (it->is_src_pair && it->name_src_pair[0] == name_src2 && it->name_src_pair[1] == name_src1)
+        if (it->data_type == DATA_TYPE_CRDIF && it->name_src_pair[0] == name_src2 && it->name_src_pair[1] == name_src1)
             return *it;
     }
 
@@ -542,24 +542,24 @@ inline void set_cr_dif_to_src_pair(std::map<std::string, std::map< std::string, 
                                    std::string& name_src2,
                                    std::string& name_rec,
                                    CUSTOMREAL& cr_dif){
-    // return the first element in the vector with is_rec_pair = true
+    // return the first element in the vector with data_type == DATA_TYPE_CRDIF
 
     std::vector<DataInfo>& vdata = v[name_src1][name_rec];
 
     for (auto it = vdata.begin(); it != vdata.end(); it++){
-        if (it->is_src_pair
+        if (it->data_type == DATA_TYPE_CRDIF
         && ( (it->name_src_pair[0] == name_src1 && it->name_src_pair[1] == name_src2)
          ||  (it->name_src_pair[0] == name_src2 && it->name_src_pair[1] == name_src1) )) {
-            it->cr_dif_travel_time = cr_dif;
+            it->dif_travel_time = cr_dif;
         }
     }
 }
 
 
 inline bool get_if_any_src_pair(std::vector<DataInfo>& v){
-    // return the first element in the vector with is_rec_pair = true
+    // return the first element in the vector with data_type == DATA_TYPE_CRDIF
     for (auto it = v.begin(); it != v.end(); it++){
-        if (it->is_src_pair)
+        if (it->data_type == DATA_TYPE_CRDIF)
             return true;
     }
 

--- a/include/src_rec.h
+++ b/include/src_rec.h
@@ -75,45 +75,82 @@ public:
 class DataInfo {
 public:
 
+    // weight
     CUSTOMREAL data_weight  = 1.0;   // the weight in the src_rec file
     CUSTOMREAL weight       = 1.0;   // the actual weight in the inversion, equal   data_weight * weight about the data type;
     CUSTOMREAL weight_reloc = 1.0;   // the actual weight for relocation,   equal   data_weight * weight about the data type;
 
+    // phase
     std::string phase = "unknown";
+    // int phase_id = -1;
+    
+    // if true, this data is a dual data, used for generating kernel, but not for obj estimation (if true, data type = 2 or 3)
+    bool dual_data   = false;   
 
-    bool dual_data   = false;   // if true, this data is a dual data, used for generating kernel, but not for obj estimation (if true, data type = 2 or 3)
+    // three types of data, infomation is conbined together to reduce RAM:
 
-    bool is_src_rec = false; // absolute traveltime, single source - receiver
+    // data_type: replace 
+    // 0: absolute traveltime, single source - receiver
+    // 1: common source differential traveltime
+    // 2: common receiver differential traveltime
+    // replaces
+    // bool is_src_rec  (for case 1)
+    // bool is_src_pair (for case 2)
+    // bool is_rec_pair (for case 3)
+    int data_type = -1; 
 
     // source information
-    int         id_src   = -1;
-    std::string name_src = "unknown";
+    // for data_type = 0, id_srcs[0] is the source id; 
+    // for data_type = 1, id_srcs[0] is the source id;
+    // for data_type = 2, id_srcs[0] and id_srcs[1] are the source ids
+    std::vector<int>            id_src_pair = {-1, -1};
+    std::vector<std::string>    name_src_pair = {"unknown", "unknown"};
 
     // receiver information
-    int         id_rec   = -1;
-    std::string name_rec = "unknown";
+    // for data_type = 0, id_recs[0] is the receiver id;
+    // for data_type = 1, id_recs[0] and id_recs[1] are the receiver ids;
+    // for data_type = 2, id_recs[0] is the receiver id;
+    std::vector<int>            id_rec_pair = {-1, -1};
+    std::vector<std::string>    name_rec_pair = {"unknown", "unknown"};
 
     // traveltime
-    CUSTOMREAL travel_time     = -999.0;
-    CUSTOMREAL travel_time_obs = -999.0;
+    CUSTOMREAL travel_time     = -999.0;        // synthetic travel time from id_srcs[0] to id_recs[0]
+    CUSTOMREAL dif_travel_time = -999.0;        // synthetic differential travel time for specific data tpye. (type_type = 1 or 2)
+    // observed time
+    CUSTOMREAL time_observation = -999.0;        // observed travel time for data_type = 0; observed differential travel time for data_type = 1 or 2 
 
-    // receiver pair infomation
-    bool is_rec_pair                       = false;   // common source differential traveltime
-    std::vector<int>         id_rec_pair   = {-1,-1};
-    std::vector<std::string> name_rec_pair = {"unknown","unknown"};
 
-    // common source differential travel time
-    CUSTOMREAL cs_dif_travel_time     = -999.0;
-    CUSTOMREAL cs_dif_travel_time_obs = -999.0;
+    // bool is_src_rec = false; // absolute traveltime, single source - receiver
 
-    // source pair infomation
-    bool                     is_src_pair   = false;   // common receiver differential traveltime (for future)
-    std::vector<int>         id_src_pair   = {-1,-1};
-    std::vector<std::string> name_src_pair = {"unknown","unknown"};
+    // // source information
+    // int         id_src   = -1;
+    // std::string name_src = "unknown";
 
-    // common receiver differential travel time
-    CUSTOMREAL cr_dif_travel_time     = -999.0;
-    CUSTOMREAL cr_dif_travel_time_obs = -999.0;
+    // // receiver information
+    // int         id_rec   = -1;
+    // std::string name_rec = "unknown";
+
+    // // traveltime
+    // CUSTOMREAL travel_time     = -999.0;
+    // CUSTOMREAL travel_time_obs = -999.0;
+
+    // // receiver pair infomation
+    // bool is_rec_pair                       = false;   // common source differential traveltime
+    // std::vector<int>         id_rec_pair   = {-1,-1};
+    // std::vector<std::string> name_rec_pair = {"unknown","unknown"};
+
+    // // common source differential travel time
+    // CUSTOMREAL cs_dif_travel_time     = -999.0;
+    // CUSTOMREAL cs_dif_travel_time_obs = -999.0;
+
+    // // source pair infomation
+    // bool                     is_src_pair   = false;   // common receiver differential traveltime (for future)
+    // std::vector<int>         id_src_pair   = {-1,-1};
+    // std::vector<std::string> name_src_pair = {"unknown","unknown"};
+
+    // // common receiver differential travel time
+    // CUSTOMREAL cr_dif_travel_time     = -999.0;
+    // CUSTOMREAL cr_dif_travel_time_obs = -999.0;
 
     // source relocation
     CUSTOMREAL DTi          = 0.0;

--- a/include/src_rec.h
+++ b/include/src_rec.h
@@ -153,10 +153,11 @@ public:
     // CUSTOMREAL cr_dif_travel_time_obs = -999.0;
 
     // source relocation
-    CUSTOMREAL DTi          = 0.0;
-    CUSTOMREAL DTj          = 0.0;
-    CUSTOMREAL DTk          = 0.0;
+    // CUSTOMREAL DTi          = 0.0;
+    // CUSTOMREAL DTj          = 0.0;
+    // CUSTOMREAL DTk          = 0.0;
 
+    // DTi is stored in DTi_pair[0]
     std::vector<CUSTOMREAL> DTi_pair = {0.0, 0.0};
     std::vector<CUSTOMREAL> DTj_pair = {0.0, 0.0};
     std::vector<CUSTOMREAL> DTk_pair = {0.0, 0.0};

--- a/src/SrcRecWeight.cxx
+++ b/src/SrcRecWeight.cxx
@@ -396,10 +396,10 @@ void write_src_rec_file_with_weight(std::string src_rec_file_out, \
             for (const auto& data : v_data){
 
                 // absolute traveltime data
-                if (data.is_src_rec){
+                if (data.data_type == DATA_TYPE_ABS) {
                     SrcRecInfo  rec      = rec_map[name_rec];
 
-                    CUSTOMREAL  travel_time = data.travel_time_obs; // write the observed travel time
+                    CUSTOMREAL  travel_time = data.time_observation; // write the observed travel time
 
                     // receiver line : id_src id_rec name_rec lat lon elevation_m phase epicentral_distance_km arival_time
                     ofs << std::setw(7) << std::right << std::setfill(' ') << src.id << " "
@@ -417,7 +417,7 @@ void write_src_rec_file_with_weight(std::string src_rec_file_out, \
                 }else {
                     std::cout << "Error: data type is not defined." << std::endl;
                     exit(1);
-                } // end of if (data.is_src_rec)
+                }
 
             } // end of for (const auto& data : v_data)
         } // end of for (auto iter = data_map_back[name_src].begin(); iter != data_map_back[name_src].end(); iter++)

--- a/src/input_params.cpp
+++ b/src/input_params.cpp
@@ -2044,7 +2044,7 @@ void InputParams::generate_src_map_with_common_receiver(std::map<std::string, st
         for(auto iter = data_map_tmp.begin(); iter != data_map_tmp.end(); iter++){
             for (auto iter2 = iter->second.begin(); iter2 != iter->second.end(); iter2++){
                 for (auto& data: iter2->second){
-                    if (data.is_src_pair){
+                    if (data.data_type == DATA_TYPE_CRDIF) {
                         // add this source and turn to the next source
                         src_map_comm_rec_tmp[iter->first] = src_map[iter->first];
                         // add this source to the list of sources that will be looped in each iteration
@@ -2142,7 +2142,7 @@ void InputParams::gather_all_arrival_times_to_main(){
                             // store travel time in all datainfo element of each src-rec pair
                             data_map_all[name_src][iter->first].at(i_data).travel_time = iter->second.at(i_data).travel_time;
                             // common source double difference traveltime
-                            data_map_all[name_src][iter->first].at(i_data).cs_dif_travel_time = iter->second.at(i_data).cs_dif_travel_time;
+                            data_map_all[name_src][iter->first].at(i_data).dif_travel_time = iter->second.at(i_data).dif_travel_time;
                         }
                     }
                 } else {
@@ -2177,7 +2177,7 @@ void InputParams::gather_all_arrival_times_to_main(){
                         // then receive travel time (and common source double difference traveltime)
                         for (auto& data: data_map_all[name_src][name_rec]) {
                             recv_cr_single_sim(&(data.travel_time), id_sim_group);
-                            recv_cr_single_sim(&(data.cs_dif_travel_time), id_sim_group);
+                            recv_cr_single_sim(&(data.dif_travel_time), id_sim_group);
                         }
                     }
 
@@ -2198,7 +2198,7 @@ void InputParams::gather_all_arrival_times_to_main(){
                         // then send travel time (and common source double difference traveltime)
                         for (auto& data: iter->second){
                             send_cr_single_sim(&(data.travel_time), 0);
-                            send_cr_single_sim(&(data.cs_dif_travel_time), 0);
+                            send_cr_single_sim(&(data.dif_travel_time), 0);
                         }
                     }
                 } else {
@@ -2305,9 +2305,9 @@ void InputParams::gather_traveltimes_and_calc_syn_diff(){
             for (auto iter = data_map_all.begin(); iter != data_map_all.end(); iter++){
                 for (auto iter2 = iter->second.begin(); iter2 != iter->second.end(); iter2++){
                     for (auto& data: iter2->second){
-                        if (data.is_src_pair){
-                            data.cr_dif_travel_time = data_map_all[data.name_src_pair[0]][data.name_rec].at(0).travel_time \
-                                                    - data_map_all[data.name_src_pair[1]][data.name_rec].at(0).travel_time;
+                        if (data.data_type == DATA_TYPE_CRDIF) {
+                            data.dif_travel_time = data_map_all[data.name_src_pair[0]][data.name_rec_pair[0]].at(0).travel_time \
+                                                    - data_map_all[data.name_src_pair[1]][data.name_rec_pair[0]].at(0).travel_time;
                             // n_total_src_pair++;
                        }
                     }
@@ -2330,7 +2330,7 @@ void InputParams::gather_traveltimes_and_calc_syn_diff(){
                     for (int i_data = 0; i_data < (int)iter->second.size(); i_data++){
                         auto& data = iter->second.at(i_data);
 
-                        if (data.is_src_pair){
+                        if (data.data_type == DATA_TYPE_CRDIF) {
                             std::string name_src1 = data.name_src_pair[0];
                             std::string name_src2 = data.name_src_pair[1];
                             // name_src1 should be the same as name_src for set_cr_dif_to_src_pair (replace otherwise)
@@ -2342,7 +2342,7 @@ void InputParams::gather_traveltimes_and_calc_syn_diff(){
 
                             if (id_sim_group == 0) {
                                 // this source is calculated in the main simultaneous run group
-                                set_cr_dif_to_src_pair(data_map, name_src1, name_src2, name_rec, data.cr_dif_travel_time);
+                                set_cr_dif_to_src_pair(data_map, name_src1, name_src2, name_rec, data.dif_travel_time);
                             } else {
                                 // send signal with dummy int
                                 int dummy = 0;
@@ -2357,7 +2357,7 @@ void InputParams::gather_traveltimes_and_calc_syn_diff(){
                                 // send index of data
                                 send_i_single_sim(&i_data, id_sim_group);
                                 // send travel time difference
-                                send_cr_single_sim(&(data.cr_dif_travel_time), id_sim_group);
+                                send_cr_single_sim(&(data.dif_travel_time), id_sim_group);
                             }
                         }
                     }
@@ -2640,11 +2640,12 @@ void InputParams::write_src_rec_file(int i_inv, int i_iter) {
                         // common source differential traveltime data
                         CUSTOMREAL  cs_dif_travel_time;
 
-                        if (get_is_srcrec_swap() && !is_tele){ // reverse swap src and rec
-                            cs_dif_travel_time = data.cr_dif_travel_time;
-                        } else {// do not swap
-                            cs_dif_travel_time = data.cs_dif_travel_time;
-                        }
+                        // if (get_is_srcrec_swap() && !is_tele){ // reverse swap src and rec
+                        //     cs_dif_travel_time = data.dif_travel_time;
+                        // } else {// do not swap
+                        //     cs_dif_travel_time = data.dif_travel_time;
+                        // }
+                        cs_dif_travel_time = data.dif_travel_time;
 
                         SrcRecInfo& rec1 = rec_map_back[name_rec1];
                         SrcRecInfo& rec2 = rec_map_back[name_rec2];
@@ -2671,11 +2672,12 @@ void InputParams::write_src_rec_file(int i_inv, int i_iter) {
                         // common receiver differential traveltime data
                         CUSTOMREAL  cr_dif_travel_time;
 
-                        if (get_is_srcrec_swap() && !is_tele){ // reverse swap src and rec
-                            cr_dif_travel_time = data.cs_dif_travel_time;
-                        } else {// do not swap
-                            cr_dif_travel_time = data.cr_dif_travel_time;
-                        }
+                        // if (get_is_srcrec_swap() && !is_tele){ // reverse swap src and rec
+                        //     cr_dif_travel_time = data.cs_dif_travel_time;
+                        // } else {// do not swap
+                        //     cr_dif_travel_time = data.cr_dif_travel_time;
+                        // }
+                        cr_dif_travel_time = data.dif_travel_time;
 
                         SrcRecInfo& rec1 = rec_map_back[name_rec1];
                         SrcRecInfo& src2 = src_map_back[name_src2];
@@ -2790,7 +2792,7 @@ void InputParams::write_src_rec_file(int i_inv, int i_iter) {
                             }
 
                             SrcRecInfo rec             = rec_map_back[name_rec1];
-                            CUSTOMREAL travel_time_obs = data.travel_time_obs - rec_map_all[name_src].tau_opt;
+                            CUSTOMREAL travel_time_obs = data.time_observation - rec_map_all[name_src].tau_opt;
 
                             // receiver line : id_src id_rec name_rec lat lon elevation_m phase epicentral_distance_km arival_time
                             ofs << std::setw(7) << std::right << std::setfill(' ') << src.id << " "
@@ -2816,7 +2818,7 @@ void InputParams::write_src_rec_file(int i_inv, int i_iter) {
                             // common source differential traveltime data
                             SrcRecInfo& rec1 = rec_map_back[name_rec1];
                             SrcRecInfo& rec2 = rec_map_back[name_rec2];
-                            CUSTOMREAL  cs_dif_travel_time_obs = data.cr_dif_travel_time_obs;
+                            CUSTOMREAL  cs_dif_travel_time_obs = data.time_observation;
 
                             // receiver pair line : id_src id_rec1 name_rec1 lat1 lon1 elevation_m1 id_rec2 name_rec2 lat2 lon2 elevation_m2 phase differential_arival_time
                             ofs << std::setw(7) << std::right << std::setfill(' ') <<  src.id << " "
@@ -2846,7 +2848,7 @@ void InputParams::write_src_rec_file(int i_inv, int i_iter) {
                             // common receiver differential traveltime data
                             SrcRecInfo& rec1 = rec_map_back[name_rec1];
                             SrcRecInfo& src2 = src_map_back[name_src2];
-                            CUSTOMREAL  cr_dif_travel_time_obs = data.cs_dif_travel_time_obs - rec_map_all[name_src].tau_opt + rec_map_all[name_src2].tau_opt;
+                            CUSTOMREAL  cr_dif_travel_time_obs = data.time_observation - rec_map_all[name_src].tau_opt + rec_map_all[name_src2].tau_opt;
 
 
                             // receiver pair line : id_src id_rec1 name_rec1 lat1 lon1 elevation_m1 id_rec2 name_rec2 lat2 lon2 elevation_m2 phase differential_arival_time
@@ -2990,21 +2992,21 @@ void InputParams::station_correction_update(CUSTOMREAL stepsize){
                 for (const auto& data : it_rec->second){
 
                     // absolute traveltime
-                    if (data.is_src_rec){
+                    if (data.data_type == DATA_TYPE_ABS){
                         std::cout << "teleseismic data, absolute traveltime is not supported now" << std::endl;
 
                     // common receiver differential traveltime
-                    } else if (data.is_src_pair) {
+                    } else if (data.data_type == DATA_TYPE_CRDIF) {
                         std::cout << "teleseismic data, common receiver differential traveltime is not supported now" << std::endl;
 
                     // common source differential traveltime
-                    } else if (data.is_rec_pair) { // here is for checking the flag (if data is swapped, is_rec_pair was originally is_src_pair)
-                        std::string name_src   = data.name_src;
+                    } else if (data.data_type == DATA_TYPE_CSDIF) { // here is for checking the flag (if data is swapped, is_rec_pair was originally is_src_pair)
+                        std::string name_src   = data.name_src_pair[0];
                         std::string name_rec1  = data.name_rec_pair[0];
                         std::string name_rec2  = data.name_rec_pair[1];
 
-                        CUSTOMREAL syn_dif_time = data.cs_dif_travel_time;
-                        CUSTOMREAL obs_dif_time = data.cs_dif_travel_time_obs;
+                        CUSTOMREAL syn_dif_time = data.dif_travel_time;
+                        CUSTOMREAL obs_dif_time = data.time_observation;
                         rec_map_all[name_rec1].sta_correct_kernel += _2_CR *(syn_dif_time - obs_dif_time \
                                     + rec_map_all[name_rec1].sta_correct - rec_map_all[name_rec2].sta_correct)*data.weight;
                         rec_map_all[name_rec2].sta_correct_kernel -= _2_CR *(syn_dif_time - obs_dif_time \

--- a/src/oneD_inversion.cpp
+++ b/src/oneD_inversion.cpp
@@ -681,7 +681,7 @@ void OneDInversion::calculate_synthetic_traveltime_and_adjoint_source(InputParam
 
             ///////////////// calculate synthetic traveltime //////////////////
 
-            const std::string name_rec = data.name_rec;
+            const std::string name_rec = data.name_rec_pair[0];
             // get position of the receiver
             CUSTOMREAL rec_r = depth2radius(IP.rec_map[name_rec].dep);
             CUSTOMREAL rec_lon = IP.rec_map[name_rec].lon*DEG2RAD;   // in radian
@@ -696,7 +696,7 @@ void OneDInversion::calculate_synthetic_traveltime_and_adjoint_source(InputParam
             data.travel_time = traveltime;
 
             // for common source differentail arrival time, calculate differential time in addition
-            if (data.is_rec_pair) {
+            if (data.data_type == DATA_TYPE_CSDIF) {
                 const std::string name_rec2 = data.name_rec_pair[1];
                 CUSTOMREAL rec_r2 = depth2radius(IP.rec_map[name_rec2].dep);
                 CUSTOMREAL rec_lon2 = IP.rec_map[name_rec2].lon*DEG2RAD;   // in radian
@@ -708,7 +708,7 @@ void OneDInversion::calculate_synthetic_traveltime_and_adjoint_source(InputParam
 
                 // 2d interporlation, to find the traveltime at (distance, rec_r) on the field of T_1dinv on the mesh meshgrid(t_1dinv, r_1dinv)
                 CUSTOMREAL traveltime2 = interpolate_2d_traveltime(distance2, rec_r2);
-                data.cs_dif_travel_time = traveltime - traveltime2;
+                data.dif_travel_time = traveltime - traveltime2;
             }
 
 
@@ -716,9 +716,9 @@ void OneDInversion::calculate_synthetic_traveltime_and_adjoint_source(InputParam
 
 
             // calculate adjoint source
-            if (data.is_src_rec){
+            if (data.data_type == DATA_TYPE_ABS) {
                 CUSTOMREAL syn_time       = data.travel_time;
-                CUSTOMREAL obs_time       = data.travel_time_obs;
+                CUSTOMREAL obs_time       = data.time_observation;
 
                 // assign local weight
                 CUSTOMREAL  local_weight = _1_CR;

--- a/src/optimizer.cpp
+++ b/src/optimizer.cpp
@@ -204,7 +204,7 @@ void Optimizer::determine_step_length_controlled(InputParams& IP, Grid& grid, in
     // broadcast_cr_single_inter_and_intra_sim(step_length_init,0);
 
 
-    std::cout << "id_sim " << id_sim << " process " << myrank << " set step length to " << step_length_init << std::endl;
+    // std::cout << "id_sim " << id_sim << " process " << myrank << " set step length to " << step_length_init << std::endl;
 
     // set new model
     set_new_model(IP, grid, step_length_init);

--- a/src/receiver.cpp
+++ b/src/receiver.cpp
@@ -27,17 +27,17 @@ void Receiver::interpolate_and_store_arrival_times_at_rec_position(InputParams& 
             for (auto it_rec = IP.data_map[name_sim_src].begin(); it_rec != IP.data_map[name_sim_src].end(); ++it_rec) {
                 for (auto& data: it_rec->second){
 
-                    if (data.is_src_rec){   // absolute traveltime
+                    if (data.data_type == DATA_TYPE_ABS){   // absolute traveltime
                         // send receivr name as a starting signal for interpolation
 
                         // send dummy integer with key
                         broadcast_i_single(mykey_send, 0);
-                        broadcast_str(data.name_rec, 0);
+                        broadcast_str(data.name_rec_pair[0], 0);
 
                         // store travel time on single receiver and double receivers (what is double receivers? by CHEN Jing)
                         // store travel time from name_sim_src(src_name) to it_rec->first(rec_name)
                         data.travel_time = interpolate_travel_time(grid, IP, name_sim_src, it_rec->first);
-                    } else if (data.is_rec_pair) {
+                    } else if (data.data_type == DATA_TYPE_CSDIF) {     // common source differential traveltime
                         // store travel time from name_sim_src(src_name) to rec1_name and rec2_name
                         // calculate travel times for two receivers
                         broadcast_i_single(mykey_send, 0);
@@ -53,11 +53,11 @@ void Receiver::interpolate_and_store_arrival_times_at_rec_position(InputParams& 
                         data.travel_time = travel_time;
 
                         // calculate and store travel time difference
-                        data.cs_dif_travel_time = travel_time - travel_time_2;
-                    } else if (data.is_src_pair) {
+                        data.dif_travel_time = travel_time - travel_time_2;
+                    } else if (data.data_type == DATA_TYPE_CRDIF) {     // common receiver differential traveltime
                         // store travel time from name_sim_src(src1_name) to it_rec->first(rec_name)
                         broadcast_i_single(mykey_send, 0);
-                        broadcast_str(data.name_rec, 0);
+                        broadcast_str(data.name_rec_pair[0], 0);
                         data.travel_time = interpolate_travel_time(grid, IP, name_sim_src, it_rec->first);
 
                     } else {
@@ -117,16 +117,16 @@ void Receiver::calculate_adjoint_source(InputParams& IP, const std::string& name
                 //
                 // absolute traveltime
                 //
-                if (data.is_src_rec){
+                if (data.data_type == DATA_TYPE_ABS) {
                     if (!IP.get_use_abs()){ // if we do not use abs data, ignore to consider the total obj and adjoint source
                         continue;
                     }
 
 
-                    std::string name_src      = data.name_src;
-                    std::string name_rec      = data.name_rec;
+                    std::string name_src      = data.name_src_pair[0];
+                    std::string name_rec      = data.name_rec_pair[0];
                     CUSTOMREAL syn_time       = data.travel_time;
-                    CUSTOMREAL obs_time       = data.travel_time_obs;
+                    CUSTOMREAL obs_time       = data.time_observation;
 
                     // assign local weight
                     CUSTOMREAL  local_weight = _1_CR;
@@ -161,17 +161,17 @@ void Receiver::calculate_adjoint_source(InputParams& IP, const std::string& name
                 //
                 // common receiver differential traveltime && we use this data
                 //
-                } else if (data.is_src_pair) {
+                } else if (data.data_type == DATA_TYPE_CRDIF) {
                     if (!((IP.get_use_cr() && !IP.get_is_srcrec_swap()) ||
                           (IP.get_use_cs() &&  IP.get_is_srcrec_swap())))
                         continue;   // if we do not use this data (cr + not swap) or (cs + swap) or (cs + tele), ignore to consider the adjoint source
 
                     std::string name_src1 = data.name_src_pair[0];
                     std::string name_src2 = data.name_src_pair[1];
-                    std::string name_rec  = data.name_rec;
+                    std::string name_rec  = data.name_rec_pair[0];
 
-                    CUSTOMREAL syn_dif_time   = data.cr_dif_travel_time;
-                    CUSTOMREAL obs_dif_time   = data.cr_dif_travel_time_obs;
+                    CUSTOMREAL syn_dif_time   = data.dif_travel_time;
+                    CUSTOMREAL obs_dif_time   = data.time_observation;
 
                     // assign local weight
                     CUSTOMREAL  local_weight = _1_CR;
@@ -220,8 +220,8 @@ void Receiver::calculate_adjoint_source(InputParams& IP, const std::string& name
                     } else if (name_sim_src == name_src2) { // after modification, this case does not occur. since  name_sim_src = data.name_src = data.name_src_pair[0]
                         // thus, this part indicate an error.
                         std::cout   << "cs_dif data strcuture error occur. name_sim_src: " << name_sim_src
-                                    << ", data.name_src: " << data.name_src
                                     << ", data.name_src_pair[0]: " << data.name_src_pair[0]
+                                    << ", data.name_src_pair[1]: " << data.name_src_pair[1]
                                     << std::endl;
                     } else {
                         std::cout << "error match of data in function: calculate_adjoint_source() " << std::endl;
@@ -230,18 +230,18 @@ void Receiver::calculate_adjoint_source(InputParams& IP, const std::string& name
                 //
                 // common source differential traveltime
                 //
-                } else if (data.is_rec_pair) {
+                } else if (data.data_type == DATA_TYPE_CSDIF) {
                     if (!((IP.get_use_cs() && !IP.get_is_srcrec_swap()) ||
                           (IP.get_use_cr() &&  IP.get_is_srcrec_swap()) ||
                           (IP.get_use_cs() &&  is_tele                )))
                         continue; // if we do not use this data (cs + not swap) or (cr + swap), ignore to consider the total obj and adjoint source
 
-                    std::string name_src  = data.name_src;
+                    std::string name_src  = data.name_src_pair[0];
                     std::string name_rec1 = data.name_rec_pair[0];
                     std::string name_rec2 = data.name_rec_pair[1];
 
-                    CUSTOMREAL syn_dif_time = data.cs_dif_travel_time;
-                    CUSTOMREAL obs_dif_time = data.cs_dif_travel_time_obs;
+                    CUSTOMREAL syn_dif_time = data.dif_travel_time;
+                    CUSTOMREAL obs_dif_time = data.time_observation;
 
                     if(is_tele){    // station correction for teleseismic data
                         syn_dif_time = syn_dif_time + IP.rec_map[name_rec1].sta_correct - IP.rec_map[name_rec2].sta_correct;
@@ -341,15 +341,15 @@ std::vector<CUSTOMREAL> Receiver:: calculate_obj_and_residual(InputParams& IP) {
                     //
                     // absolute traveltime
                     //
-                    if (data.is_src_rec){
+                    if (data.data_type == DATA_TYPE_ABS) {
 
-                        // error check (data.name_src_pair must be equal to name_sim1 and name_sim2)
-                        if (data.name_src != name_sim_src) continue;
+                        // error check (data.name_src_pair[0] must be equal to name_sim_src)
+                        if (data.name_src_pair[0] != name_sim_src) continue;
 
-                        std::string name_src      = data.name_src;
-                        std::string name_rec      = data.name_rec;
+                        std::string name_src      = data.name_src_pair[0];
+                        std::string name_rec      = data.name_rec_pair[0];
                         CUSTOMREAL syn_time       = data.travel_time;
-                        CUSTOMREAL obs_time       = data.travel_time_obs;
+                        CUSTOMREAL obs_time       = data.time_observation;
 
                         bool is_tele = (IP.get_src_point(name_src).is_out_of_region || IP.get_rec_point(name_rec).is_out_of_region);
                         if (is_tele){
@@ -380,17 +380,17 @@ std::vector<CUSTOMREAL> Receiver:: calculate_obj_and_residual(InputParams& IP) {
 
 
 
-                    } else if (data.is_src_pair) {
+                    } else if (data.data_type == DATA_TYPE_CRDIF) {  // common receiver differential traveltime
 
                         std::string name_src1 = data.name_src_pair[0];
                         std::string name_src2 = data.name_src_pair[1];
-                        std::string name_rec  = data.name_rec;
+                        std::string name_rec  = data.name_rec_pair[0];
 
                         // error check (data.name_src_pair must be equal to name_sim1 and name_sim2)
                         if (name_sim_src != name_src1 && name_sim_src != name_src2) continue;
 
-                        CUSTOMREAL syn_dif_time   = data.cr_dif_travel_time;
-                        CUSTOMREAL obs_dif_time   = data.cr_dif_travel_time_obs;
+                        CUSTOMREAL syn_dif_time   = data.dif_travel_time;
+                        CUSTOMREAL obs_dif_time   = data.time_observation;
 
                         bool is_tele = (IP.get_src_point(name_src1).is_out_of_region || \
                                         IP.get_src_point(name_src2).is_out_of_region || \
@@ -418,14 +418,14 @@ std::vector<CUSTOMREAL> Receiver:: calculate_obj_and_residual(InputParams& IP) {
                             obj     += 1.0 * my_square(syn_dif_time - obs_dif_time)*data.weight;
                         }
 
-                    } else if (data.is_rec_pair) {
+                    } else if (data.data_type == DATA_TYPE_CSDIF) {   // common source differential traveltime
 
-                        std::string name_src  = data.name_src;
+                        std::string name_src  = data.name_src_pair[0];
                         std::string name_rec1 = data.name_rec_pair[0];
                         std::string name_rec2 = data.name_rec_pair[1];
 
-                        CUSTOMREAL syn_dif_time = data.cs_dif_travel_time;
-                        CUSTOMREAL obs_dif_time = data.cs_dif_travel_time_obs;
+                        CUSTOMREAL syn_dif_time = data.dif_travel_time;
+                        CUSTOMREAL obs_dif_time = data.time_observation;
 
                         bool is_tele = (IP.get_src_point(name_src).is_out_of_region || \
                                         IP.get_rec_point(name_rec1).is_out_of_region || \
@@ -731,8 +731,8 @@ void Receiver::calculate_T_gradient(InputParams& IP, Grid& grid, const std::stri
             for (auto iter = IP.data_map[name_sim_src].begin(); iter != IP.data_map[name_sim_src].end(); iter++){
                 for (auto& data: iter->second) {
                     // case 1: absolute traveltime for reloc
-                    if (data.is_src_rec && IP.get_use_abs_reloc()){   // abs data && we use it
-                        std::string name_rec = data.name_rec;
+                    if (data.data_type == DATA_TYPE_ABS && IP.get_use_abs_reloc()){   // abs data && we use it
+                        std::string name_rec = data.name_rec_pair[0];
 
                         if(IP.rec_map[name_rec].is_stop) continue;  // if this receiver (swapped source) is already located
 
@@ -751,7 +751,8 @@ void Receiver::calculate_T_gradient(InputParams& IP, Grid& grid, const std::stri
 
 
                     // case 2: common receiver (swapped source) double difference (double source, or double swapped receiver) for reloc
-                    } else if (data.is_rec_pair && IP.get_use_cr_reloc()) {  // common receiver data (swapped common source) and we use it.
+                    // in reloc, must swapped. thus, use cr mean sc here
+                    } else if (data.data_type == DATA_TYPE_CSDIF && IP.get_use_cr_reloc()) {  // common receiver data (swapped common source) and we use it.
                         std::string name_rec1 = data.name_rec_pair[0];
                         std::string name_rec2 = data.name_rec_pair[1];
 
@@ -778,10 +779,10 @@ void Receiver::calculate_T_gradient(InputParams& IP, Grid& grid, const std::stri
                         data.DTj_pair[1]  = DTijk[1];
                         data.DTk_pair[1]  = DTijk[2];
 
-                    } else if (data.is_src_pair && IP.get_use_cs_reloc()) {    // common source data (swapped common receiver) and we use it.
+                    } else if (data.data_type == DATA_TYPE_CRDIF && IP.get_use_cs_reloc()) {    // common source data (swapped common receiver) and we use it.
                         std::string name_src1 = data.name_src_pair[0];
                         std::string name_src2 = data.name_src_pair[1];
-                        std::string name_rec  = data.name_rec;
+                        std::string name_rec  = data.name_rec_pair[0];
 
                         if(IP.rec_map[name_rec].is_stop) continue;  // if this receiver (swapped source) is already located
 
@@ -1088,71 +1089,81 @@ std::vector<CUSTOMREAL> Receiver::calculate_obj_reloc(InputParams& IP, int i_ite
                     if (data.dual_data) continue; // dual data is not used for calculating obj and residual
 
                     // case 1: absolute traveltime for reloc
-                    if (data.is_src_rec){     // abs data && we use it
-                        std::string name_rec = data.name_rec;
+                    if (data.data_type == DATA_TYPE_ABS){     // abs data && we use it
+                        std::string name_rec = data.name_rec_pair[0];
+
+                        CUSTOMREAL travel_time     = data.travel_time;
+                        CUSTOMREAL travel_time_obs = data.time_observation;
 
                         // assign obj
                         if (IP.get_use_abs_reloc()){
-                            IP.rec_map[name_rec].vobj_src_reloc     += data.weight_reloc * my_square(data.travel_time - data.travel_time_obs + IP.rec_map[name_rec].tau_opt);
-                            obj                                     += data.weight_reloc * my_square(data.travel_time - data.travel_time_obs + IP.rec_map[name_rec].tau_opt);
+                            IP.rec_map[name_rec].vobj_src_reloc     += data.weight_reloc * my_square(travel_time - travel_time_obs + IP.rec_map[name_rec].tau_opt);
+                            obj                                     += data.weight_reloc * my_square(travel_time - travel_time_obs + IP.rec_map[name_rec].tau_opt);
                         }
                         // assign obj
-                        obj_abs                                     += data.weight_reloc * my_square(data.travel_time - data.travel_time_obs + IP.rec_map[name_rec].tau_opt);
+                        obj_abs                                     += data.weight_reloc * my_square(travel_time - travel_time_obs + IP.rec_map[name_rec].tau_opt);
 
                         // assign residual
-                        res                                         +=          (data.travel_time - data.travel_time_obs + IP.rec_map[name_rec].tau_opt);
-                        res_sq                                      += my_square(data.travel_time - data.travel_time_obs + IP.rec_map[name_rec].tau_opt);
+                        res                                         +=          (travel_time - travel_time_obs + IP.rec_map[name_rec].tau_opt);
+                        res_sq                                      += my_square(travel_time - travel_time_obs + IP.rec_map[name_rec].tau_opt);
 
-                        res_abs                                     +=          (data.travel_time - data.travel_time_obs + IP.rec_map[name_rec].tau_opt);
-                        res_abs_sq                                  += my_square(data.travel_time - data.travel_time_obs + IP.rec_map[name_rec].tau_opt);
+                        res_abs                                     +=          (travel_time - travel_time_obs + IP.rec_map[name_rec].tau_opt);
+                        res_abs_sq                                  += my_square(travel_time - travel_time_obs + IP.rec_map[name_rec].tau_opt);
 
                     // case 2: common receiver (swapped source) double difference (double source, or double swapped receiver) for reloc
-                    } else if (data.is_rec_pair ) {  // common receiver data (swapped common source)
+                    } else if (data.data_type == DATA_TYPE_CSDIF ) {  // common receiver data (swapped common source)
 
                         std::string name_rec1 = data.name_rec_pair[0];
                         std::string name_rec2 = data.name_rec_pair[1];
 
                         // if(IP.rec_map[name_rec1].is_stop && IP.rec_map[name_rec2].is_stop) continue;
 
+                        CUSTOMREAL cs_dif_travel_time     = data.dif_travel_time;
+                        CUSTOMREAL cs_dif_travel_time_obs = data.time_observation;
+
                         // assign obj (for EQ1, obj+1, for EQ2, obj+1, and for total obj also +1)
                         if (IP.get_use_cr_reloc()){
-                            IP.rec_map[name_rec1].vobj_src_reloc+= 1.0 * data.weight_reloc * my_square(data.cs_dif_travel_time - data.cs_dif_travel_time_obs + IP.rec_map[name_rec1].tau_opt - IP.rec_map[name_rec2].tau_opt);
-                            IP.rec_map[name_rec2].vobj_src_reloc+= 1.0 * data.weight_reloc * my_square(data.cs_dif_travel_time - data.cs_dif_travel_time_obs + IP.rec_map[name_rec1].tau_opt - IP.rec_map[name_rec2].tau_opt);
-                            obj                                 += 1.0 * data.weight_reloc * my_square(data.cs_dif_travel_time - data.cs_dif_travel_time_obs + IP.rec_map[name_rec1].tau_opt - IP.rec_map[name_rec2].tau_opt);
+                            IP.rec_map[name_rec1].vobj_src_reloc+= 1.0 * data.weight_reloc * my_square(cs_dif_travel_time - cs_dif_travel_time_obs + IP.rec_map[name_rec1].tau_opt - IP.rec_map[name_rec2].tau_opt);
+                            IP.rec_map[name_rec2].vobj_src_reloc+= 1.0 * data.weight_reloc * my_square(cs_dif_travel_time - cs_dif_travel_time_obs + IP.rec_map[name_rec1].tau_opt - IP.rec_map[name_rec2].tau_opt);
+                            obj                                 += 1.0 * data.weight_reloc * my_square(cs_dif_travel_time - cs_dif_travel_time_obs + IP.rec_map[name_rec1].tau_opt - IP.rec_map[name_rec2].tau_opt);
                         }
 
                         // assign obj
-                        obj_cs_dif                              += 1.0 * data.weight_reloc * my_square(data.cs_dif_travel_time - data.cs_dif_travel_time_obs + IP.rec_map[name_rec1].tau_opt - IP.rec_map[name_rec2].tau_opt);
+                        obj_cs_dif                              += 1.0 * data.weight_reloc * my_square(cs_dif_travel_time - cs_dif_travel_time_obs + IP.rec_map[name_rec1].tau_opt - IP.rec_map[name_rec2].tau_opt);
 
                         // assign residual
-                        res                                     += 1.0 *          (data.cs_dif_travel_time - data.cs_dif_travel_time_obs + IP.rec_map[name_rec1].tau_opt - IP.rec_map[name_rec2].tau_opt);
-                        res_sq                                  += 1.0 * my_square(data.cs_dif_travel_time - data.cs_dif_travel_time_obs + IP.rec_map[name_rec1].tau_opt - IP.rec_map[name_rec2].tau_opt);
+                        res                                     += 1.0 *          (cs_dif_travel_time - cs_dif_travel_time_obs + IP.rec_map[name_rec1].tau_opt - IP.rec_map[name_rec2].tau_opt);
+                        res_sq                                  += 1.0 * my_square(cs_dif_travel_time - cs_dif_travel_time_obs + IP.rec_map[name_rec1].tau_opt - IP.rec_map[name_rec2].tau_opt);
 
-                        res_cs_dif                              += 1.0 *          (data.cs_dif_travel_time - data.cs_dif_travel_time_obs + IP.rec_map[name_rec1].tau_opt - IP.rec_map[name_rec2].tau_opt);
-                        res_cs_dif_sq                           += 1.0 * my_square(data.cs_dif_travel_time - data.cs_dif_travel_time_obs + IP.rec_map[name_rec1].tau_opt - IP.rec_map[name_rec2].tau_opt);
+                        res_cs_dif                              += 1.0 *          (cs_dif_travel_time - cs_dif_travel_time_obs + IP.rec_map[name_rec1].tau_opt - IP.rec_map[name_rec2].tau_opt);
+                        res_cs_dif_sq                           += 1.0 * my_square(cs_dif_travel_time - cs_dif_travel_time_obs + IP.rec_map[name_rec1].tau_opt - IP.rec_map[name_rec2].tau_opt);
 
                         // }
 
-                    } else if (data.is_src_pair) {  // we only record the obj of this kind of data
-                        std::string name_rec = data.name_rec;
+                    } else if (data.data_type == DATA_TYPE_CRDIF) {  // we only record the obj of this kind of data
+                        std::string name_rec = data.name_rec_pair[0];
 
                         // if(IP.rec_map[name_rec].is_stop) continue;
 
+                        CUSTOMREAL cr_dif_travel_time     = data.dif_travel_time;
+                        CUSTOMREAL cr_dif_travel_time_obs = data.time_observation;
+
+
                         // assign obj
                         if (IP.get_use_cs_reloc()){
-                            IP.rec_map[name_rec].vobj_src_reloc     += 1.0 * data.weight_reloc * my_square(data.cr_dif_travel_time - data.cr_dif_travel_time_obs);
-                            obj                                     += 1.0 * data.weight_reloc * my_square(data.cr_dif_travel_time - data.cr_dif_travel_time_obs);
+                            IP.rec_map[name_rec].vobj_src_reloc     += 1.0 * data.weight_reloc * my_square(cr_dif_travel_time - cr_dif_travel_time_obs);
+                            obj                                     += 1.0 * data.weight_reloc * my_square(cr_dif_travel_time - cr_dif_travel_time_obs);
                         }
 
                         // assign obj
-                        obj_cr_dif                                  += 1.0 * data.weight_reloc * my_square(data.cr_dif_travel_time - data.cr_dif_travel_time_obs);
+                        obj_cr_dif                                  += 1.0 * data.weight_reloc * my_square(cr_dif_travel_time - cr_dif_travel_time_obs);
 
                         // assign residual
-                        res                                         += 1.0 *          (data.cr_dif_travel_time - data.cr_dif_travel_time_obs);
-                        res_sq                                      += 1.0 * my_square(data.cr_dif_travel_time - data.cr_dif_travel_time_obs);
+                        res                                         += 1.0 *          (cr_dif_travel_time - cr_dif_travel_time_obs);
+                        res_sq                                      += 1.0 * my_square(cr_dif_travel_time - cr_dif_travel_time_obs);
 
-                        res_cr_dif                                  += 1.0 *          (data.cr_dif_travel_time - data.cr_dif_travel_time_obs);
-                        res_cr_dif_sq                               += 1.0 * my_square(data.cr_dif_travel_time - data.cr_dif_travel_time_obs);
+                        res_cr_dif                                  += 1.0 *          (cr_dif_travel_time - cr_dif_travel_time_obs);
+                        res_cr_dif_sq                               += 1.0 * my_square(cr_dif_travel_time - cr_dif_travel_time_obs);
 
                     } else {    // unsupported data (swapped common receiver, or others)
                         continue;
@@ -1235,13 +1246,13 @@ void Receiver::calculate_grad_obj_src_reloc(InputParams& IP, const std::string& 
         for (auto iter = IP.data_map[name_sim_src].begin(); iter != IP.data_map[name_sim_src].end(); iter++){
             for (const auto& data: iter->second) {
                 // case 1: absolute traveltime for reloc
-                if (data.is_src_rec && IP.get_use_abs_reloc()){   // abs data && we use it
-                    std::string name_rec = data.name_rec;
+                if (data.data_type == DATA_TYPE_ABS && IP.get_use_abs_reloc()){   // abs data && we use it
+                    std::string name_rec = data.name_rec_pair[0];
 
                     if(IP.rec_map[name_rec].is_stop) continue;  // if this receiver (swapped source) is already located
 
                     CUSTOMREAL syn_time       = data.travel_time;
-                    CUSTOMREAL obs_time       = data.travel_time_obs;
+                    CUSTOMREAL obs_time       = data.time_observation;
 
                     // local weight
                     CUSTOMREAL local_weight = 1.0;
@@ -1273,14 +1284,14 @@ void Receiver::calculate_grad_obj_src_reloc(InputParams& IP, const std::string& 
                     // count the data
                     IP.rec_map[name_rec].Ndata      += 1;
                 // case 2: common receiver (swapped source) double difference (double source, or double swapped receiver) for reloc
-                } else if (data.is_rec_pair && IP.get_use_cr_reloc()) {  // common receiver data (swapped common source) and we use it.
+                } else if (data.data_type == DATA_TYPE_CSDIF && IP.get_use_cr_reloc()) {  // common receiver data (swapped common source) and we use it.
                     std::string name_rec1 = data.name_rec_pair[0];
                     std::string name_rec2 = data.name_rec_pair[1];
 
                     if(IP.rec_map[name_rec1].is_stop && IP.rec_map[name_rec2].is_stop) continue;  // if both receivers (swapped sources) are already located
 
-                    CUSTOMREAL syn_dif_time       = data.cs_dif_travel_time;
-                    CUSTOMREAL obs_dif_time       = data.cs_dif_travel_time_obs;
+                    CUSTOMREAL syn_dif_time       = data.dif_travel_time;
+                    CUSTOMREAL obs_dif_time       = data.time_observation;
 
                     // assign local weight
                     CUSTOMREAL  local_weight = 1.0;
@@ -1324,15 +1335,15 @@ void Receiver::calculate_grad_obj_src_reloc(InputParams& IP, const std::string& 
                     }
 
                 // case 3: common source (swapped receiver) double difference (double receiver, or double swapped source) for reloc
-                } else if (data.is_src_pair && IP.get_use_cs_reloc()) {  // common receiver data (swapped common source) and we use it.
+                } else if (data.data_type == DATA_TYPE_CRDIF && IP.get_use_cs_reloc()) {  // common receiver data (swapped common source) and we use it.
                     std::string name_src1 = data.name_src_pair[0];
                     std::string name_src2 = data.name_src_pair[1];
-                    std::string name_rec  = data.name_rec;
+                    std::string name_rec  = data.name_rec_pair[0];
 
                     if(IP.rec_map[name_rec].is_stop) continue;  // if both receivers (swapped sources) are already located
 
-                    CUSTOMREAL syn_dif_time       = data.cr_dif_travel_time;
-                    CUSTOMREAL obs_dif_time       = data.cr_dif_travel_time_obs;
+                    CUSTOMREAL syn_dif_time       = data.dif_travel_time;
+                    CUSTOMREAL obs_dif_time       = data.time_observation;
 
                     // assign local weight
                     CUSTOMREAL  local_weight = 1.0;

--- a/src/receiver.cpp
+++ b/src/receiver.cpp
@@ -745,9 +745,9 @@ void Receiver::calculate_T_gradient(InputParams& IP, Grid& grid, const std::stri
                         broadcast_str(name_rec, 0);
 
                         calculate_T_gradient_one_rec(grid, IP, name_rec, DTijk);
-                        data.DTi = DTijk[0];
-                        data.DTj = DTijk[1];
-                        data.DTk = DTijk[2];
+                        data.DTi_pair[0] = DTijk[0];
+                        data.DTj_pair[0] = DTijk[1];
+                        data.DTk_pair[0] = DTijk[2];
 
 
                     // case 2: common receiver (swapped source) double difference (double source, or double swapped receiver) for reloc
@@ -794,9 +794,9 @@ void Receiver::calculate_T_gradient(InputParams& IP, Grid& grid, const std::stri
                         // send reeiver name
                         broadcast_str(name_rec, 0);
                         calculate_T_gradient_one_rec(grid, IP, name_rec, DTijk);
-                        data.DTi  = DTijk[0];
-                        data.DTj  = DTijk[1];
-                        data.DTk  = DTijk[2];
+                        data.DTi_pair[0]  = DTijk[0];
+                        data.DTj_pair[0]  = DTijk[1];
+                        data.DTk_pair[0]  = DTijk[2];
                     } else {
                         // we have some other types of data or we have three above-mentioned data but we do not use them
                         continue;
@@ -1276,10 +1276,10 @@ void Receiver::calculate_grad_obj_src_reloc(InputParams& IP, const std::string& 
                     else                                        local_weight *= ((local_dis - dis_weight[0])/(dis_weight[1] - dis_weight[0]) * (dis_weight[3] - dis_weight[2]) + dis_weight[2]);
 
                     // assign kernel
-                    IP.rec_map[name_rec].grad_chi_k += (syn_time - obs_time + IP.rec_map[name_rec].tau_opt) * data.DTk * data.weight_reloc * local_weight;
-                    IP.rec_map[name_rec].grad_chi_j += (syn_time - obs_time + IP.rec_map[name_rec].tau_opt) * data.DTj * data.weight_reloc * local_weight;
-                    IP.rec_map[name_rec].grad_chi_i += (syn_time - obs_time + IP.rec_map[name_rec].tau_opt) * data.DTi * data.weight_reloc * local_weight;
-                    IP.rec_map[name_rec].grad_tau   += (syn_time - obs_time + IP.rec_map[name_rec].tau_opt)            * data.weight_reloc * local_weight;
+                    IP.rec_map[name_rec].grad_chi_k += (syn_time - obs_time + IP.rec_map[name_rec].tau_opt) * data.DTk_pair[0] * data.weight_reloc * local_weight;
+                    IP.rec_map[name_rec].grad_chi_j += (syn_time - obs_time + IP.rec_map[name_rec].tau_opt) * data.DTj_pair[0] * data.weight_reloc * local_weight;
+                    IP.rec_map[name_rec].grad_chi_i += (syn_time - obs_time + IP.rec_map[name_rec].tau_opt) * data.DTi_pair[0] * data.weight_reloc * local_weight;
+                    IP.rec_map[name_rec].grad_tau   += (syn_time - obs_time + IP.rec_map[name_rec].tau_opt)                    * data.weight_reloc * local_weight;
 
                     // count the data
                     IP.rec_map[name_rec].Ndata      += 1;
@@ -1371,9 +1371,9 @@ void Receiver::calculate_grad_obj_src_reloc(InputParams& IP, const std::string& 
                     else                                        local_weight *= ((local_azi - azi_weight[0])/(azi_weight[1] - azi_weight[0]) * (azi_weight[3] - azi_weight[2]) + azi_weight[2]);
 
                     // assign kernel (we only consider the DTijk of first source (swapped receiver), because only the DTijk of the first source is calculated)
-                    IP.rec_map[name_rec].grad_chi_k += (syn_dif_time - obs_dif_time) * data.DTk * data.weight_reloc * local_weight;
-                    IP.rec_map[name_rec].grad_chi_j += (syn_dif_time - obs_dif_time) * data.DTj * data.weight_reloc * local_weight;
-                    IP.rec_map[name_rec].grad_chi_i += (syn_dif_time - obs_dif_time) * data.DTi * data.weight_reloc * local_weight;
+                    IP.rec_map[name_rec].grad_chi_k += (syn_dif_time - obs_dif_time) * data.DTk_pair[0] * data.weight_reloc * local_weight;
+                    IP.rec_map[name_rec].grad_chi_j += (syn_dif_time - obs_dif_time) * data.DTj_pair[0] * data.weight_reloc * local_weight;
+                    IP.rec_map[name_rec].grad_chi_i += (syn_dif_time - obs_dif_time) * data.DTi_pair[0] * data.weight_reloc * local_weight;
                     IP.rec_map[name_rec].grad_tau   += 0;       // common swapped source, so ortime is cancelled.
                     IP.rec_map[name_rec].Ndata      += 1;
 

--- a/src/src_rec.cpp
+++ b/src/src_rec.cpp
@@ -204,14 +204,14 @@ void parse_src_rec_file(std::string& src_rec_file, \
                     data.weight_reloc= data.data_weight * abs_time_local_weight_reloc;
                     data.phase       = tokens[6];
 
-                    data.is_src_rec      = true;
-                    data.id_src          = src_id;
-                    data.name_src        = src_name;
-                    data.id_rec          = rec.id;
-                    data.name_rec        = rec.name;
-                    data.travel_time_obs = static_cast<CUSTOMREAL>(std::stod(tokens[7])); // store read data
+                    data.data_type          = DATA_TYPE_ABS;
+                    data.id_src_pair[0]     = src_id;
+                    data.name_src_pair[0]   = src_name;
+                    data.id_rec_pair[0]     = rec.id;
+                    data.name_rec_pair[0]   = rec.name;
+                    data.time_observation   = static_cast<CUSTOMREAL>(std::stod(tokens[7])); // store read data
 
-                    data_map[data.name_src][data.name_rec].push_back(data);
+                    data_map[data.name_src_pair[0]][data.name_rec_pair[0]].push_back(data);
 
                     // store receiver name of onle receiver line in src rec file
                     rec_name_list.push_back(rec_name_list_one_line);
@@ -252,12 +252,12 @@ void parse_src_rec_file(std::string& src_rec_file, \
                     //data.id_src_single          = src_id;
                     //data.name_src_single        = src_name;
                     // use common variables with src-rec data
-                    data.id_src          = src_id;
-                    data.name_src        = src_name;
+                    // data.id_src          = src_id;
+                    // data.name_src        = src_name;
 
                     // store the id and name of the first receiver (just used for key of the data_map)
-                    data.id_rec          = rec.id;
-                    data.name_rec        = rec.name;
+                    // data.id_rec          = rec.id;
+                    // data.name_rec        = rec.name;
 
                     // determine this data is cr_dif or cs_dif
                     bool is_cr_dif = tokens[11].find("cr")!=std::string::npos;
@@ -279,14 +279,16 @@ void parse_src_rec_file(std::string& src_rec_file, \
                         rec_name_list_one_line.push_back(src2.name);
                         rec_name_list_one_line.push_back("cr");
                         // common receiver differential traveltime data
-                        data.is_src_pair            = true;
+                        data.data_type              = DATA_TYPE_CRDIF;
                         data.id_src_pair            = {src_id, src2.id};
                         data.name_src_pair          = {src_name, src2.name};
-                        data.cr_dif_travel_time_obs = static_cast<CUSTOMREAL>(std::stod(tokens[12])); // store read data
+                        data.id_rec_pair            = {rec.id, -1}; 
+                        data.name_rec_pair          = {rec.name, "unknown"}; 
+                        data.time_observation       = static_cast<CUSTOMREAL>(std::stod(tokens[12])); // store read data
 
                         data.weight         = data.data_weight * cr_dif_time_local_weight;
                         data.weight_reloc   = data.data_weight * cr_dif_time_local_weight_reloc;
-                        data_map[data.name_src_pair[0]][data.name_rec].push_back(data); // USE ONE-DATAMAP-FOR-ONE-SRCREC-LINE
+                        data_map[data.name_src_pair[0]][data.name_rec_pair[0]].push_back(data); // USE ONE-DATAMAP-FOR-ONE-SRCREC-LINE
                     } else {
                         // cs_dif data
                         SrcRecInfo rec2;
@@ -305,14 +307,16 @@ void parse_src_rec_file(std::string& src_rec_file, \
                         rec_name_list_one_line.push_back("cs");
 
                         // common source differential traveltime data
-                        data.is_rec_pair            = true;
+                        data.data_type              = DATA_TYPE_CSDIF;
                         data.id_rec_pair            = {rec.id, rec2.id};
                         data.name_rec_pair          = {rec.name, rec2.name};
-                        data.cs_dif_travel_time_obs = static_cast<CUSTOMREAL>(std::stod(tokens[12])); // store read data
-
+                        data.id_src_pair            = {src_id, -1};
+                        data.name_src_pair          = {src_name, "unknown"};
+                        data.time_observation       = static_cast<CUSTOMREAL>(std::stod(tokens[12]));
+                        
                         data.weight       = data.data_weight * cs_dif_time_local_weight;
                         data.weight_reloc = data.data_weight * cs_dif_time_local_weight_reloc;
-                        data_map[data.name_src][data.name_rec_pair[0]].push_back(data); // USE ONE-DATAMAP-FOR-ONE-SRCREC-LINE
+                        data_map[data.name_src_pair[0]][data.name_rec_pair[0]].push_back(data); // USE ONE-DATAMAP-FOR-ONE-SRCREC-LINE
                     }
 
                     // store receiver name of one receiver line in src rec file
@@ -384,22 +388,22 @@ void parse_src_rec_file(std::string& src_rec_file, \
         for (auto iter = data_map.begin(); iter != data_map.end(); iter++){
             for (auto iter2 = iter->second.begin(); iter2 != iter->second.end(); iter2++){
                 for (const auto& data : iter2->second) {
-                    if (data.is_src_rec) {
-                        std::cout   << "source name: "     << data.name_src
-                                    << ", receiver name: " << data.name_rec
-                                    << ", traveltime: "    << data.travel_time_obs
+                    if (data.data_type == DATA_TYPE_ABS) {
+                        std::cout   << "source name: "     << data.name_src_pair[0]
+                                    << ", receiver name: " << data.name_rec_pair[0]
+                                    << ", traveltime: "    << data.time_observation
                                     << std::endl;
-                    } else if (data.is_rec_pair) {
-                        std::cout   << "source name: "          << data.name_src
+                    } else if (data.data_type == DATA_TYPE_CSDIF) {
+                        std::cout   << "source name: "          << data.name_src_pair[0]
                                     << ", receiver pair name: " << data.name_rec_pair[0]
                                     << ", "                     << data.name_rec_pair[1]
-                                    << ", traveltime: "         << data.cs_dif_travel_time_obs
+                                    << ", traveltime: "         << data.time_observation
                                     << std::endl;
-                    } else if (data.is_src_pair) {
+                    } else if (data.data_type == DATA_TYPE_CRDIF) {
                         std::cout   << "source pair name: "     << data.name_src_pair[0]
                                     << ", "                     << data.name_src_pair[1]
-                                    << ", receiver name: "      << data.name_rec
-                                    << ", traveltime: "         << data.cr_dif_travel_time_obs
+                                    << ", receiver name: "      << data.name_rec_pair[0]
+                                    << ", traveltime: "         << data.time_observation
                                     << std::endl;
                     } else {
                         std::cout   << "error type of data" << std::endl;
@@ -616,9 +620,9 @@ void separate_region_and_tele_src_rec_data(std::map<std::string, SrcRecInfo>    
             for (auto& data: it_rec->second){
 
                 // absolute traveltime
-                if(data.is_src_rec){
-                    std::string name_src = data.name_src;
-                    std::string name_rec = data.name_rec;
+                if(data.data_type == DATA_TYPE_ABS){
+                    std::string name_src = data.name_src_pair[0];
+                    std::string name_rec = data.name_rec_pair[0];
 
                     // if name_src is out of region
                     if(src_map_tele.find(name_src) != src_map_tele.end()){
@@ -641,10 +645,10 @@ void separate_region_and_tele_src_rec_data(std::map<std::string, SrcRecInfo>    
                     }
 
                 // common receiver differential traveltime
-                } else if (data.is_src_pair){
+                } else if (data.data_type == DATA_TYPE_CRDIF){
                     std::string name_src1 = data.name_src_pair[0];
                     std::string name_src2 = data.name_src_pair[1];
-                    std::string name_rec  = data.name_rec;
+                    std::string name_rec  = data.name_rec_pair[0];
 
                     // if both sources are out of region
                     if(src_map_tele.find(name_src1) != src_map_tele.end() \
@@ -673,8 +677,8 @@ void separate_region_and_tele_src_rec_data(std::map<std::string, SrcRecInfo>    
                     }
 
                 // common source differential traveltime
-                } else if (data.is_rec_pair){
-                    std::string name_src  = data.name_src;
+                } else if (data.data_type == DATA_TYPE_CSDIF){
+                    std::string name_src  = data.name_src_pair[0];
                     std::string name_rec1 = data.name_rec_pair[0];
                     std::string name_rec2 = data.name_rec_pair[1];
 
@@ -739,13 +743,13 @@ void separate_region_and_tele_src_rec_data(std::map<std::string, SrcRecInfo>    
             for(auto it_rec = it_src->second.begin(); it_rec != it_src->second.end(); it_rec++){
                 for(auto& data: it_rec->second){
                     // absolute traveltime
-                   if(data.is_src_rec){
+                   if(data.data_type == DATA_TYPE_ABS){
                         data.weight = data.weight / total_abs_local_data_weight * (total_abs_local_data_weight + total_cr_dif_local_data_weight + total_cs_dif_local_data_weight);
                    // common receiver differential traveltime
-                   } else if (data.is_src_pair){
+                   } else if (data.data_type == DATA_TYPE_CRDIF){
                         data.weight = data.weight / total_cr_dif_local_data_weight * (total_abs_local_data_weight + total_cr_dif_local_data_weight + total_cs_dif_local_data_weight);
                    // common source differential traveltime
-                   } else if (data.is_rec_pair){
+                   } else if (data.data_type == DATA_TYPE_CSDIF){
                         data.weight = data.weight / total_cs_dif_local_data_weight * (total_abs_local_data_weight + total_cr_dif_local_data_weight + total_cs_dif_local_data_weight);
                    }
                 }
@@ -767,15 +771,15 @@ void separate_region_and_tele_src_rec_data(std::map<std::string, SrcRecInfo>    
             for(auto it_rec = it_src->second.begin(); it_rec != it_src->second.end(); it_rec++){
                 for(auto& data: it_rec->second){
                     // absolute traveltime
-                   if(data.is_src_rec){
+                   if(data.data_type == DATA_TYPE_ABS){
                        data.weight_reloc = data.weight_reloc / total_abs_local_data_weight_reloc * (total_abs_local_data_weight_reloc + total_cr_dif_local_data_weight_reloc + total_cs_dif_local_data_weight_reloc);
 
                    // common receiver differential traveltime
-                   } else if (data.is_src_pair){
+                   } else if (data.data_type == DATA_TYPE_CRDIF){
                        data.weight_reloc = data.weight_reloc / total_cr_dif_local_data_weight_reloc * (total_abs_local_data_weight_reloc + total_cr_dif_local_data_weight_reloc + total_cs_dif_local_data_weight_reloc);
 
                    // common source differential traveltime
-                   } else if (data.is_rec_pair){
+                   } else if (data.data_type == DATA_TYPE_CSDIF){
                        data.weight_reloc = data.weight_reloc / total_cs_dif_local_data_weight_reloc * (total_abs_local_data_weight_reloc + total_cr_dif_local_data_weight_reloc + total_cs_dif_local_data_weight_reloc);
                    }
                 }
@@ -791,15 +795,15 @@ void separate_region_and_tele_src_rec_data(std::map<std::string, SrcRecInfo>    
         for(auto it_rec = it_src->second.begin(); it_rec != it_src->second.end(); it_rec++){
             for (auto& data: it_rec->second){
                 // absolute traveltime
-                if(data.is_src_rec){
+                if(data.data_type == DATA_TYPE_ABS){
                     N_abs_local_data += 1;
 
                 // common receiver differential traveltime
-                } else if (data.is_src_pair){
+                } else if (data.data_type == DATA_TYPE_CRDIF){
                     N_cr_dif_local_data += 1;
 
                 // common source differential traveltime
-                } else if (data.is_rec_pair){
+                } else if (data.data_type == DATA_TYPE_CSDIF){
                     N_cs_dif_local_data += 1;
                 }
             }
@@ -836,22 +840,22 @@ void separate_region_and_tele_src_rec_data(std::map<std::string, SrcRecInfo>    
         for (auto iter = data_map.begin(); iter != data_map.end(); iter++){
             for (auto iter2 = iter->second.begin(); iter2 != iter->second.end(); iter2++){
                 for (const auto& data : iter2->second) {
-                    if (data.is_src_rec) {
-                        std::cout   << "source name: "     << data.name_src
-                                    << ", receiver name: " << data.name_rec
-                                    << ", traveltime: "    << data.travel_time_obs
+                    if (data.data_type == DATA_TYPE_ABS) {
+                        std::cout   << "source name: "     << data.name_src_pair[0]
+                                    << ", receiver name: " << data.name_rec_pair[0]
+                                    << ", traveltime: "    << data.time_observation
                                     << std::endl;
-                    } else if (data.is_rec_pair) {
-                        std::cout   << "source name: "          << data.name_src
+                    } else if (data.data_type == DATA_TYPE_CSDIF) {
+                        std::cout   << "source name: "          << data.name_src_pair[0]
                                     << ", receiver pair name: " << data.name_rec_pair[0]
                                     << ", "                     << data.name_rec_pair[1]
-                                    << ", traveltime: "         << data.cs_dif_travel_time_obs
+                                    << ", traveltime: "         << data.time_observation
                                     << std::endl;
-                    } else if (data.is_src_pair) {
+                    } else if (data.data_type == DATA_TYPE_CRDIF) {
                         std::cout   << "source pair name: "     << data.name_src_pair[0]
                                     << ", "                     << data.name_src_pair[1]
-                                    << ", receiver name: "      << data.name_rec
-                                    << ", traveltime: "         << data.cr_dif_travel_time_obs
+                                    << ", receiver name: "      << data.name_rec_pair[0]
+                                    << ", traveltime: "         << data.time_observation
                                     << std::endl;
                     } else {
                         std::cout   << "error type of data" << std::endl;
@@ -877,22 +881,22 @@ void separate_region_and_tele_src_rec_data(std::map<std::string, SrcRecInfo>    
         for (auto iter = data_map_tele.begin(); iter != data_map_tele.end(); iter++){
             for (auto iter2 = iter->second.begin(); iter2 != iter->second.end(); iter2++){
                 for (const auto& data : iter2->second) {
-                    if (data.is_src_rec) {
-                        std::cout   << "source name: "     << data.name_src
-                                    << ", receiver name: " << data.name_rec
-                                    << ", traveltime: "    << data.travel_time_obs
+                    if (data.data_type == DATA_TYPE_ABS) {
+                        std::cout   << "source name: "     << data.name_src_pair[0]
+                                    << ", receiver name: " << data.name_rec_pair[0]
+                                    << ", traveltime: "    << data.time_observation
                                     << std::endl;
-                    } else if (data.is_rec_pair) {
-                        std::cout   << "source name: "          << data.name_src
+                    } else if (data.data_type == DATA_TYPE_CSDIF) {
+                        std::cout   << "source name: "          << data.name_src_pair[0]
                                     << ", receiver pair name: " << data.name_rec_pair[0]
                                     << ", "                     << data.name_rec_pair[1]
-                                    << ", traveltime: "         << data.cs_dif_travel_time_obs
+                                    << ", traveltime: "         << data.time_observation
                                     << std::endl;
-                    } else if (data.is_src_pair) {
+                    } else if (data.data_type == DATA_TYPE_CRDIF) {
                         std::cout   << "source pair name: "     << data.name_src_pair[0]
                                     << ", "                     << data.name_src_pair[1]
-                                    << ", receiver name: "      << data.name_rec
-                                    << ", traveltime: "         << data.cr_dif_travel_time_obs
+                                    << ", receiver name: "      << data.name_rec_pair[0]
+                                    << ", traveltime: "         << data.time_observation
                                     << std::endl;
                     } else {
                         std::cout   << "error type of data" << std::endl;
@@ -931,85 +935,68 @@ void do_swap_src_rec(std::map<std::string, SrcRecInfo> &src_map, \
 
                 DataInfo tmp_data = data;
 
-                if (tmp_data.is_src_rec){
+                if (tmp_data.data_type == DATA_TYPE_ABS){
                     // absolute traveltime  ->  absolute traveltime
                     // |    abs     |               |    abs     |
                     // |  s0 - r0   |       ->      |  r0 - s0   |
                     // |            |               |            |
                     // |            |               |            |
 
-                    tmp_data.id_src   = data.id_rec;
-                    tmp_data.name_src = data.name_rec;
-                    tmp_data.id_rec   = data.id_src;
-                    tmp_data.name_rec = data.name_src;
+                    tmp_data.id_src_pair[0]   = data.id_rec_pair[0];
+                    tmp_data.name_src_pair[0] = data.name_rec_pair[0];
+                    tmp_data.id_rec_pair[0]   = data.id_src_pair[0];
+                    tmp_data.name_rec_pair[0] = data.name_src_pair[0];
                     tmp_data.dual_data = false; // is not a dual data. contribute both objective function and kernel
-                    tmp_data_map[tmp_data.name_src][tmp_data.name_rec].push_back(tmp_data);
+                    tmp_data_map[tmp_data.name_src_pair[0]][tmp_data.name_rec_pair[0]].push_back(tmp_data);
 
 
-                } else if (tmp_data.is_rec_pair) {
+                } else if (tmp_data.data_type == DATA_TYPE_CSDIF){
                     // common source differential traveltime  ->  common receiver differential traveltime
                     // |    cs_dif     |            |          cr_dif           |
                     // |   s0 - r1     |    ->      |   r1 - s0     r2 - s0     |
                     // |   |           |            |        |           |      |
                     // |   r2          |            |        r2          r1     |
 
-                    tmp_data.is_rec_pair            = false;
-                    tmp_data.is_src_pair            = true;
+                    tmp_data.data_type              = DATA_TYPE_CRDIF;
 
                     tmp_data.id_src_pair            = data.id_rec_pair;
                     tmp_data.name_src_pair          = data.name_rec_pair;
 
-                    tmp_data.id_rec                 = data.id_src;
-                    tmp_data.name_rec               = data.name_src;
-
-                    tmp_data.cr_dif_travel_time_obs = data.cs_dif_travel_time_obs;
-
-                    tmp_data.id_rec_pair            = {-1, -1};
-                    tmp_data.name_rec_pair          = {"unknown", "unknown"};
+                    tmp_data.id_rec_pair            = data.id_src_pair;
+                    tmp_data.name_rec_pair          = data.name_src_pair;
 
                     // one data
                     tmp_data.dual_data = false; // one is not a dual data. contribute both objective function and kernel
-                    tmp_data.name_src = tmp_data.name_src_pair[0];
-                    tmp_data.id_src   = tmp_data.id_src_pair[0];
-                    tmp_data_map[tmp_data.name_src][tmp_data.name_rec].push_back(tmp_data);
+                    tmp_data_map[tmp_data.name_src_pair[0]][tmp_data.name_rec_pair[0]].push_back(tmp_data);
 
                     // the other data
                     // Note: name_src = cr_dif time always represent time(src, rec1) - time(src,rec2). Thus, -1.0 is necessary
                     // Meanwhile, name_src(key) must equal data.name_src_pair[0] and data.name_src
                     tmp_data.dual_data = true; // the other is a dual data. contribute kernel only
                     tmp_data.name_src_pair = {data.name_rec_pair[1],data.name_rec_pair[0]};
-                    tmp_data.cr_dif_travel_time_obs = -1.0 * data.cs_dif_travel_time_obs;
-                    tmp_data.name_src = tmp_data.name_src_pair[0];
-                    tmp_data.id_src   = tmp_data.id_src_pair[0];
-                    tmp_data_map[tmp_data.name_src][tmp_data.name_rec].push_back(tmp_data);
+                    tmp_data.id_src_pair   = {data.id_rec_pair[1], data.id_rec_pair[0]};
+                    tmp_data.time_observation = -1.0 * data.time_observation;
+                    tmp_data_map[tmp_data.name_src_pair[0]][tmp_data.name_rec_pair[0]].push_back(tmp_data);
 
 
-                } else if (tmp_data.is_src_pair) {
+                } else if (tmp_data.data_type == DATA_TYPE_CRDIF){
                     // common receiver differential traveltime  ->  common source differential traveltime
                     // |    cr_dif     |        |    cs_dif     |
                     // |   s0 - r3     |    ->  |   r3 - s0     |
                     // |        |      |        |   |           |
                     // |        s1     |        |   s1          |
 
-                    tmp_data.is_src_pair            = false;
-                    tmp_data.is_rec_pair            = true;
+                    tmp_data.data_type              = DATA_TYPE_CSDIF;
+
+                    tmp_data.id_src_pair            = data.id_rec_pair;
+                    tmp_data.name_src_pair          = data.name_rec_pair;
 
                     tmp_data.id_rec_pair            = data.id_src_pair;
                     tmp_data.name_rec_pair          = data.name_src_pair;
 
-                    tmp_data.id_src                 = data.id_rec;
-                    tmp_data.name_src               = data.name_rec;
-
-                    tmp_data.cs_dif_travel_time_obs = data.cr_dif_travel_time_obs;
-
-                    tmp_data.id_src_pair            = {-1, -1};
-                    tmp_data.name_src_pair          = {"unknown", "unknown"};
-
                     // only need one data for common source dif
                     tmp_data.dual_data = false; // one is not a dual data. contribute both objective function and kernel
-                    tmp_data.name_rec = tmp_data.name_rec_pair[0];
-                    tmp_data.id_rec   = tmp_data.id_rec_pair[0];
-                    tmp_data_map[tmp_data.name_src][tmp_data.name_rec].push_back(tmp_data);
+                    tmp_data_map[tmp_data.name_src_pair[0]][tmp_data.name_rec_pair[0]].push_back(tmp_data);
 
                 }
 
@@ -1057,25 +1044,25 @@ void do_swap_src_rec(std::map<std::string, SrcRecInfo> &src_map, \
             for(auto it_rec = it_src->second.begin(); it_rec != it_src->second.end(); it_rec++){
                 for(const auto& data: it_rec->second){
 
-                    if (data.is_src_rec){
+                    if (data.data_type == DATA_TYPE_ABS){
                         std::cout   << "key: it_src, it_rec: " << it_src->first << ", " << it_rec->first
-                                    << ", absolute traveltime: " << data.travel_time_obs
-                                    << ", source name: "       << data.name_src
-                                    << ", receiver name: "     << data.name_rec
+                                    << ", absolute traveltime: " << data.time_observation
+                                    << ", source name: "       << data.name_src_pair[0]
+                                    << ", receiver name: "     << data.name_rec_pair[0]
                                     << std::endl;
-                    } else if (data.is_rec_pair){
+                    } else if (data.data_type == DATA_TYPE_CSDIF){
                         std::cout   << "key: it_src, it_rec: "  << it_src->first << ", " << it_rec->first
-                                    << ", common source differential traveltime: " << data.cs_dif_travel_time_obs
-                                    << ", source name: "                         << data.name_src
+                                    << ", common source differential traveltime: " << data.time_observation
+                                    << ", source name: "                         << data.name_src_pair[0]
                                     << ", receiver pair name: "                  << data.name_rec_pair[0]
                                     << ", "                                      << data.name_rec_pair[1]
                                     << std::endl;
-                    } else if (data.is_src_pair){
+                    } else if (data.data_type == DATA_TYPE_CRDIF){
                         std::cout   << "key: it_src, it_rec: "    << it_src->first << ", " << it_rec->first
-                                    << ", common receiver differential traveltime: " << data.cr_dif_travel_time_obs
+                                    << ", common receiver differential traveltime: " << data.time_observation
                                     << ", source pair name: "                      << data.name_src_pair[0]
                                     << ", "                                        << data.name_src_pair[1]
-                                    << ", receiver name: "                         << data.name_rec
+                                    << ", receiver name: "                         << data.name_rec_pair[0]
                                     << std::endl;
                     }
                 }
@@ -1111,25 +1098,23 @@ void do_not_swap_src_rec(std::map<std::string, SrcRecInfo> &src_map, \
                 DataInfo tmp_data = data;
 
                 // common receiver differential traveltime
-                if (tmp_data.is_src_pair) {
+                if (tmp_data.data_type == DATA_TYPE_CRDIF){
                     // keep the original data, meanwhile, add cr_dif data with the other source
                     // |    cr_dif     |            |          cr_dif           |
                     // |   s0 - r3     |    ->      |   s0 - r3     s1 - r3     |
                     // |        |      |            |        |           |      |
                     // |        s1     |            |        s1          s0     |
                     tmp_data.dual_data = false; // one is not a dual data. contribute both objective function and kernel
-                    tmp_data_map[tmp_data.name_src_pair[0]][tmp_data.name_rec].push_back(tmp_data);     // original data
+                    tmp_data_map[tmp_data.name_src_pair[0]][tmp_data.name_rec_pair[0]].push_back(tmp_data);     // original data
 
                     // the other data with the other source.
                     // Note: name_src = cr_dif time always represent time(src1, rec) - time(src2,rec). Thus, -1 is necessary
                     // Meanwhile, name_src(key) must equal name_src_pair[0]
                     tmp_data.dual_data = true; // the other is a dual data. contribute kernel only
-                    tmp_data.name_src       = data.name_src_pair[1];
-                    tmp_data.id_src         = data.id_src_pair[1];
                     tmp_data.name_src_pair  = {data.name_src_pair[1],data.name_src_pair[0]};
                     tmp_data.id_src_pair    = {data.id_src_pair[1],data.id_src_pair[0]};
-                    tmp_data.cr_dif_travel_time_obs  = -1.0 * data.cr_dif_travel_time_obs;
-                    tmp_data_map[tmp_data.name_src][tmp_data.name_rec].push_back(tmp_data);
+                    tmp_data.time_observation  = -1.0 * data.time_observation;
+                    tmp_data_map[tmp_data.name_src_pair[0]][tmp_data.name_rec_pair[0]].push_back(tmp_data);
 
                 } else {    // abs and cs_dif data does not change
                     // abs data and cs_dif data remain unchanged
@@ -1138,7 +1123,7 @@ void do_not_swap_src_rec(std::map<std::string, SrcRecInfo> &src_map, \
                     // |            |   |           |
                     // |            |   r2          |
                     tmp_data.dual_data = false; // one is not a dual data. contribute both objective function and kernel
-                    tmp_data_map[tmp_data.name_src][tmp_data.name_rec].push_back(tmp_data);
+                    tmp_data_map[tmp_data.name_src_pair[0]][tmp_data.name_rec_pair[0]].push_back(tmp_data);
                 }
 
            }
@@ -1176,25 +1161,25 @@ void do_not_swap_src_rec(std::map<std::string, SrcRecInfo> &src_map, \
             for(auto it_rec = it_src->second.begin(); it_rec != it_src->second.end(); it_rec++){
                 for(const auto& data: it_rec->second){
 
-                    if (data.is_src_rec){
+                    if (data.data_type == DATA_TYPE_ABS){
                         std::cout   << "key: it_src, it_rec: " << it_src->first << ", " << it_rec->first
-                                    << ", absolute traveltime: " << data.travel_time_obs
-                                    << ", source name: "       << data.name_src
-                                    << ", receiver name: "     << data.name_rec
+                                    << ", absolute traveltime: " << data.time_observation
+                                    << ", source name: "       << data.name_src_pair[0]
+                                    << ", receiver name: "     << data.name_rec_pair[0]
                                     << std::endl;
-                    } else if (data.is_rec_pair){
+                    } else if (data.data_type == DATA_TYPE_CSDIF){
                         std::cout   << "key: it_src, it_rec: "  << it_src->first << ", " << it_rec->first
-                                    << ", common source differential traveltime: " << data.cs_dif_travel_time_obs
-                                    << ", source name: "                         << data.name_src
+                                    << ", common source differential traveltime: " << data.time_observation
+                                    << ", source name: "                         << data.name_src_pair[0]
                                     << ", receiver pair name: "                  << data.name_rec_pair[0]
                                     << ", "                                      << data.name_rec_pair[1]
                                     << std::endl;
-                    } else if (data.is_src_pair){
+                    } else if (data.data_type == DATA_TYPE_CRDIF){
                         std::cout   << "key: it_src, it_rec: "    << it_src->first << ", " << it_rec->first
-                                    << ", common receiver differential traveltime: " << data.cr_dif_travel_time_obs
+                                    << ", common receiver differential traveltime: " << data.time_observation
                                     << ", source pair name: "                      << data.name_src_pair[0]
                                     << ", "                                        << data.name_src_pair[1]
-                                    << ", receiver name: "                         << data.name_rec
+                                    << ", receiver name: "                         << data.name_rec_pair[0]
                                     << std::endl;
                     }
                 }
@@ -1282,25 +1267,25 @@ void merge_region_and_tele_src(std::map<std::string, SrcRecInfo> &src_map,
             for(auto it_rec = it_src->second.begin(); it_rec != it_src->second.end(); it_rec++){
                 for(const auto& data: it_rec->second){
 
-                    if (data.is_src_rec){
+                    if (data.data_type == DATA_TYPE_ABS){
                         std::cout   << "key: it_src, it_rec: " << it_src->first << ", " << it_rec->first
-                                    << ", absolute traveltime: " << data.travel_time_obs
-                                    << ", source name: "       << data.name_src
-                                    << ", receiver name: "     << data.name_rec
+                                    << ", absolute traveltime: " << data.time_observation
+                                    << ", source name: "       << data.name_src_pair[0]
+                                    << ", receiver name: "     << data.name_rec_pair[0]
                                     << std::endl;
-                    } else if (data.is_rec_pair){
+                    } else if (data.data_type == DATA_TYPE_CSDIF){
                         std::cout   << "key: it_src, it_rec: "  << it_src->first << ", " << it_rec->first
-                                    << ", common source differential traveltime: " << data.cs_dif_travel_time_obs
-                                    << ", source name: "                         << data.name_src
+                                    << ", common source differential traveltime: " << data.time_observation
+                                    << ", source name: "                         << data.name_src_pair[0]
                                     << ", receiver pair name: "                  << data.name_rec_pair[0]
                                     << ", "                                      << data.name_rec_pair[1]
                                     << std::endl;
-                    } else if (data.is_src_pair){
+                    } else if (data.data_type == DATA_TYPE_CRDIF){
                         std::cout   << "key: it_src, it_rec: "    << it_src->first << ", " << it_rec->first
-                                    << ", common receiver differential traveltime: " << data.cr_dif_travel_time_obs
+                                    << ", common receiver differential traveltime: " << data.time_observation
                                     << ", source pair name: "                      << data.name_src_pair[0]
                                     << ", "                                        << data.name_src_pair[1]
-                                    << ", receiver name: "                         << data.name_rec
+                                    << ", receiver name: "                         << data.name_rec_pair[0]
                                     << std::endl;
                     }
                 }
@@ -1367,7 +1352,7 @@ void distribute_src_rec_data(std::map<std::string, SrcRecInfo>&                 
                             data_map_this_sim[src_name][iter->first].push_back(data);
 
                             // store the second receiver for rec_pair
-                            if (data.is_rec_pair){
+                            if (data.data_type == DATA_TYPE_CSDIF){
                                 rec_map_this_sim[data.name_rec_pair[1]] = rec_map[data.name_rec_pair[1]];
                                 rec_name_list_this_sim.push_back(data.name_rec_pair[1]);
                             }
@@ -1401,8 +1386,9 @@ void distribute_src_rec_data(std::map<std::string, SrcRecInfo>&                 
                                 send_data_info_inter_sim(data, dst_id_sim);
 
                                 // send the second receiver for rec_pair
-                                if (data.is_rec_pair)
+                                if (data.data_type == DATA_TYPE_CSDIF){
                                     send_rec_info_inter_sim(rec_map[data.name_rec_pair[1]], dst_id_sim);
+                                }
                             }
 
                         }
@@ -1445,10 +1431,10 @@ void distribute_src_rec_data(std::map<std::string, SrcRecInfo>&                 
                             // receive data_info from the main process of dst_id_sim
                             recv_data_info_inter_sim(tmp_DataInfo, 0);
                             // add the received data_info to the data_info
-                            data_map_this_sim[tmp_DataInfo.name_src][tmp_DataInfo.name_rec].push_back(tmp_DataInfo);
+                            data_map_this_sim[tmp_DataInfo.name_src_pair[0]][tmp_DataInfo.name_rec_pair[0]].push_back(tmp_DataInfo);
 
                             // store the second receiver for rec_pair
-                            if (tmp_DataInfo.is_rec_pair){
+                            if (tmp_DataInfo.data_type == DATA_TYPE_CSDIF){
                                 recv_rec_info_inter_sim(rec_map_this_sim[tmp_DataInfo.name_rec_pair[1]], 0);
                                 rec_name_list_this_sim.push_back(tmp_DataInfo.name_rec_pair[1]);
                             }
@@ -1669,39 +1655,18 @@ void send_data_info_inter_sim(DataInfo &data, int dest){
     send_cr_single_sim(&data.weight_reloc, dest);
     send_str_sim(data.phase, dest);
 
-    send_i_single_sim(&data.id_src, dest);
-    send_str_sim(data.name_src, dest);
-    send_i_single_sim(&data.id_rec, dest);
-    send_str_sim(data.name_rec, dest);
-
-    send_bool_single_sim(&data.is_src_rec,  dest);
-    send_bool_single_sim(&data.is_rec_pair, dest);
-    send_bool_single_sim(&data.is_src_pair, dest);
+    send_i_single_sim(&data.data_type, dest);
 
     send_bool_single_sim(&data.dual_data, dest);
 
-    if (data.is_src_rec){
-       send_cr_single_sim(&data.travel_time_obs, dest);
-    }
+    send_cr_single_sim(&data.time_observation, dest);
 
-    if (data.is_rec_pair){
-        //send_i_single_sim(&data.id_src_single, dest);
-        //send_str_sim(data.name_src_single, dest);
-        for (int ipair=0; ipair<2; ipair++){
-            send_i_single_sim(&data.id_rec_pair[ipair], dest);
-            send_str_sim(data.name_rec_pair[ipair], dest);
-        }
-        send_cr_single_sim(&data.cs_dif_travel_time_obs, dest);
-    }
+    for (int ipair=0; ipair<2; ipair++){
+        send_i_single_sim(&data.id_rec_pair[ipair], dest);
+        send_str_sim(data.name_rec_pair[ipair], dest);
 
-    if (data.is_src_pair){
-        send_i_single_sim(&data.id_rec, dest);
-        send_str_sim(data.name_rec, dest);
-        for (int ipair=0; ipair<2; ipair++){
-            send_i_single_sim(&data.id_src_pair[ipair], dest);
-            send_str_sim(data.name_src_pair[ipair], dest);
-        }
-        send_cr_single_sim(&data.cr_dif_travel_time_obs, dest);
+        send_i_single_sim(&data.id_src_pair[ipair], dest);
+        send_str_sim(data.name_src_pair[ipair], dest);
     }
 }
 
@@ -1713,39 +1678,17 @@ void recv_data_info_inter_sim(DataInfo &data, int orig){
     recv_cr_single_sim(&data.weight_reloc, orig);
     recv_str_sim(data.phase, orig);
 
-    recv_i_single_sim(&data.id_src, orig);
-    recv_str_sim(data.name_src, orig);
-    recv_i_single_sim(&data.id_rec, orig);
-    recv_str_sim(data.name_rec, orig);
-
-    recv_bool_single_sim(&data.is_src_rec, orig);
-    recv_bool_single_sim(&data.is_rec_pair, orig);
-    recv_bool_single_sim(&data.is_src_pair, orig);
+    recv_i_single_sim(&data.data_type, orig);
 
     recv_bool_single_sim(&data.dual_data, orig);
 
-    if (data.is_src_rec){
-       recv_cr_single_sim(&data.travel_time_obs, orig);
-    }
+    recv_cr_single_sim(&data.time_observation, orig);
+    
+    for (int ipair=0; ipair<2; ipair++){
+        recv_i_single_sim(&data.id_rec_pair[ipair], orig);
+        recv_str_sim(data.name_rec_pair[ipair], orig);
 
-    if (data.is_rec_pair){
-        //recv_i_single_sim(&data.id_src_single, orig);
-        //recv_str_sim(data.name_src_single, orig);
-        for (int ipair=0; ipair<2; ipair++){
-            recv_i_single_sim(&data.id_rec_pair[ipair], orig);
-            recv_str_sim(data.name_rec_pair[ipair], orig);
-        }
-        recv_cr_single_sim(&data.cs_dif_travel_time_obs, orig);
+        recv_i_single_sim(&data.id_src_pair[ipair], orig);
+        recv_str_sim(data.name_src_pair[ipair], orig);
     }
-
-    if (data.is_src_pair){
-        recv_i_single_sim(&data.id_rec, orig);
-        recv_str_sim(data.name_rec, orig);
-        for (int ipair=0; ipair<2; ipair++){
-            recv_i_single_sim(&data.id_src_pair[ipair], orig);
-            recv_str_sim(data.name_src_pair[ipair], orig);
-        }
-        recv_cr_single_sim(&data.cr_dif_travel_time_obs, orig);
-    }
-
 }


### PR DESCRIPTION
simplify the variables in datainfo to reduce RAM. 

A 34 Mb data file leads to Peak total RSS: 1.61305 GB

after the modification, it reduces to
Peak total RSS: 1.39309 GB
